### PR TITLE
Feature/#182 popconfirm

### DIFF
--- a/docs/assets/src/scss/_callouts.scss
+++ b/docs/assets/src/scss/_callouts.scss
@@ -9,23 +9,19 @@
   border: 1px solid #eee;
   border-left-width: .25rem;
   border-radius: .25rem;
-}
-
-.bd-callout h4 {
-  margin-top: 0;
-  margin-bottom: .25rem;
-}
-
-.bd-callout p:last-child {
-  margin-bottom: 0;
-}
-
-.bd-callout code {
-  border-radius: .25rem;
-}
-
-.bd-callout + .bd-callout {
-  margin-top: -.25rem;
+  h4 {
+    margin-top: 0;
+    margin-bottom: .25rem;
+  }
+  p:last-child {
+    margin-bottom: 0;
+  }
+  code {
+    border-radius: .25rem;
+  }
+  & + .bd-callout {
+    margin-top: -.25rem;
+  }
 }
 
 // Variations

--- a/docs/assets/src/scss/_content.scss
+++ b/docs/assets/src/scss/_content.scss
@@ -57,3 +57,7 @@
     font-size: 1.5rem;
   }
 }
+
+code.highlighter-rouge {
+  background-color: #efc;
+}

--- a/docs/componenti/modale.md
+++ b/docs/componenti/modale.md
@@ -255,6 +255,52 @@ Per formattare correttamente il contenuto di questa modale, aggiungere la classe
 </div>
 {% endcapture %}{% include example.html content=example %}
 
+### Modale Popconfirm
+
+{% capture example %}
+<div class="it-example-modal">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 col-lg-6">
+        <p><strong>Basico</strong></p>
+        <div class="modal popconfirm-modal" tabindex="-1" role="dialog" id="">
+            <div class="modal-dialog" role="document">
+              <div class="modal-content">
+                  <div class="modal-body">
+                    <p>Font Titillium 14px. Leading 21px.</p>
+                  </div>
+                  <div class="modal-footer">
+                    <button class="btn btn-primary btn-sm" type="button">Action one</button>
+                    <button class="btn btn-outline-secondary btn-sm" type="button" data-dismiss="modal">Action two</button>
+                  </div>
+              </div>
+            </div>
+        </div>
+      </div>
+      <div class="col-12 col-lg-6">
+        <p><strong>Con Header</strong></p>
+        <div class="modal popconfirm-modal" tabindex="-1" role="dialog" id="">
+            <div class="modal-dialog" role="document">
+              <div class="modal-content">
+                  <div class="modal-header">
+                    <h5 class="modal-title">Popconfirm header</h5>
+                  </div>
+                  <div class="modal-body">
+                    <p>Font Titillium 14px. Leading 21px.</p>
+                  </div>
+                  <div class="modal-footer">
+                    <button class="btn btn-primary btn-sm" type="button">Action one</button>
+                    <button class="btn btn-outline-secondary btn-sm" type="button" data-dismiss="modal">Action two</button>
+                  </div>
+              </div>
+            </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endcapture %}{% include example.html content=example %}
+
 ## Demo
 
 ### Modale semplice

--- a/docs/componenti/modale.md
+++ b/docs/componenti/modale.md
@@ -257,6 +257,10 @@ Per formattare correttamente il contenuto di questa modale, aggiungere la classe
 
 ### Modale Popconfirm
 
+La Modale di tipo Popconfirm può essere utilizzata per brevi messaggi di conferma. Questo particolare design si ottiene applicando la classe `popconfirm-modal` all'elemento `<div class="modal">`.
+
+Il titolo della modale è facoltativo, nel caso non fosse necessario è sufficiente rimuovere l'intero elemento `<div class="modal-header">`.
+
 {% capture example %}
 <div class="it-example-modal">
   <div class="container">

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -388,6 +388,9 @@ $modal-alert-p-distance: 32px + $v-gap*2;
 $modal-heading-border:1px solid rgba(0,0,0,0.05);
 $modal-sticky-bg:#FFF;
 $modal-body-height:50vh;
+$modal-popconfirm-p-size-mobile: 0.875rem;
+$modal-popconfirm-p-size: 0.778rem;
+$modal-popconfirm-max-width: 300px;
 
 //HEADER
 //Header slim

--- a/src/scss/custom/_dialog.scss
+++ b/src/scss/custom/_dialog.scss
@@ -93,6 +93,31 @@
 			}
 		}
 	}
+	//Popconfirm variation
+	&.popconfirm-modal{
+		.modal-dialog {
+			max-width: $modal-popconfirm-max-width;
+			margin-right: auto;
+			margin-left: auto;
+			.modal-content {
+				border-radius: $border-radius;
+			}
+			.modal-header {
+				padding-top: $v-gap*2;
+				margin-bottom: -$v-gap/2;
+			}
+			.modal-body {
+				padding-top: $v-gap*2;
+				p {
+					font-size: $modal-popconfirm-p-size-mobile;
+					margin-bottom: $v-gap*1.5;
+				}
+			}
+			.modal-footer{
+				padding-bottom: $v-gap*3;
+			}
+		}
+	}
 	// scrollable variation
 	&.it-dialog-scrollable{
 		.modal-dialog{
@@ -134,7 +159,7 @@
 			}
 		}
 	}
-	//left variaion
+	//left variation
 	.modal-dialog{
 		&.modal-dialog-left{
 			height: 100vh;
@@ -207,7 +232,18 @@
 
   //small - tablet
   @media (min-width: #{map-get($grid-breakpoints, sm)}) {
-
+		.modal{
+			//Popconfirm variation
+			&.popconfirm-modal{
+				.modal-dialog {
+					.modal-body {
+						p {
+							font-size: $modal-popconfirm-p-size;
+						}
+					}
+				}
+			}
+		}
   }
 
   //Tablet vertical


### PR DESCRIPTION
SCSS, HTML e Docs per Popconfirm.

## Descrizione
- aggiunta classe specifica a \scss\custom\_dialog.scss
- aggiunto esempio con HTML in docs\componenti\modale.md

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->

Fix #182