### PR TITLE
Update _collapse.scss

### DIFF
--- a/src/scss/custom/_collapse.scss
+++ b/src/scss/custom/_collapse.scss
@@ -35,7 +35,7 @@ $arrow-size: $font-size-base/2;
         background-color: $primary;
         color: $white;
         border-color: $primary;
-        &:after {
+        &:before {
           color: $white;
         }
       }
@@ -49,7 +49,7 @@ $arrow-size: $font-size-base/2;
         background-color: $primary;
         color: $white;
         border-color: $primary;
-        &:after {
+        &:before {
           color: $white;
         }
       }
@@ -60,7 +60,7 @@ $arrow-size: $font-size-base/2;
   &.collapse-left-icon {
     .collapse-header {
       *[data-toggle='collapse'] {
-        &:after {
+        &:before {
           content: '-';
           float: left;
           margin: 0 1rem 0 0;
@@ -70,7 +70,7 @@ $arrow-size: $font-size-base/2;
           transform: none;
         }
         &[aria-expanded='false'] {
-          &:after {
+          &:before {
             content: '+';
           }
         }
@@ -96,15 +96,15 @@ $arrow-size: $font-size-base/2;
     //transition: background-color 0.1s;
     &[aria-expanded='false'] {
       color: $primary;
-      &:after {
+      &:before {
         transform: scaleY(-1);
       }
     }
-    &[aria-expanded='false']:hover:after,
-    &[aria-expanded='true']:hover:after {
+    &[aria-expanded='false']:hover:before,
+    &[aria-expanded='true']:hover:before {
       text-decoration: none;
     }
-    &:after {
+    &:before {
       content: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHRpdGxlPml0LWNvbGxhcHNlPC90aXRsZT48ZyBpZD0iTGl2ZWxsb18xMyIgZGF0YS1uYW1lPSJMaXZlbGxvIDEzIj48cGF0aCBmaWxsPSIjN0ZCMkU1IiBkPSJNMTIsMTAuMjUsMTYuNzcsMTVhLjc1Ljc1LDAsMCwwLDEuMDYsMCwuNzQuNzQsMCwwLDAsMC0xLjA2TDEzLjA2LDkuMTlhMS41MSwxLjUxLDAsMCwwLTIuMTIsMEw2LjE3LDE0YS43NC43NCwwLDAsMCwwLDEuMDYuNzUuNzUsMCwwLDAsMS4wNiwwWiIvPjwvZz48L3N2Zz4K');
       float: right;
       width: 1.5rem;


### PR DESCRIPTION
Sostituito il selettore `:after` con il selettore `:before` per posizionare correttamente, in caso di visualizzazione da mobile, l'icona che compare a sinistra dell'elemento collassibile, quando si usa la classe `collapse-left-icon` sul container degli elementi collassabili.

<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
