### PR TITLE
Add example for icon-white in the docs

### DIFF
--- a/docs/utilities/icone.md
+++ b/docs/utilities/icone.md
@@ -50,6 +50,7 @@ Sono disponibili le classi `icon-*`, dove `*` può essere `xs`, `sm`, `lg`, `xl`
 <svg class="icon icon-warning bg-light"><use xlink:href="{{ site.baseurl }}/dist/svg/sprite.svg#it-check-circle"></use></svg>
 <svg class="icon icon-danger bg-light"><use xlink:href="{{ site.baseurl }}/dist/svg/sprite.svg#it-check-circle"></use></svg>
 <svg class="icon icon-light bg-dark"><use xlink:href="{{ site.baseurl }}/dist/svg/sprite.svg#it-check-circle"></use></svg>
+<svg class="icon icon-white bg-dark"><use xlink:href="{{ site.baseurl }}/dist/svg/sprite.svg#it-check-circle"></use></svg>
 {% endcapture %}{% include example.html content=example %}
 
 ### Allineamenti


### PR DESCRIPTION
In the docs there was no mention of the `icon-white` class that can be applied to SVG icons in order to render them in white, but it works.