### PR TITLE
Give a right color to the icons in the slimheader

### DIFF
--- a/src/scss/custom/_headerslim.scss
+++ b/src/scss/custom/_headerslim.scss
@@ -21,6 +21,9 @@
         transition: all 0.3s;
         transform-origin: center;
       }
+      svg {
+        fill: $header-slim-text-color;
+      }
       &.dropdown-toggle {
         text-transform: uppercase;
         font-size: $header-slim-brand-text-size;
@@ -31,9 +34,6 @@
           .icon {
             transform: scaleY(-1);
           }
-        }
-        svg {
-          fill: $header-slim-text-color;
         }
       }
       &.it-opener {


### PR DESCRIPTION
## Descrizione
### Before
<img width="117" alt="Schermata 2019-05-17 alle 12 11 25" src="https://user-images.githubusercontent.com/9119858/57921245-35d71f00-789d-11e9-82b4-8bc627419eac.png">

### After
<img width="120" alt="Schermata 2019-05-17 alle 12 13 06" src="https://user-images.githubusercontent.com/9119858/57921251-396aa600-789d-11e9-9219-8cd1f4c4530c.png">


## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
