### PR TITLE
Make icon colors important

### DIFF
--- a/src/scss/custom/_buttons.scss
+++ b/src/scss/custom/_buttons.scss
@@ -96,31 +96,31 @@
     fill: $primary;
 
     &.icon-white {
-      fill: $white;
+      fill: $white !important;
     }
 
     &.icon-primary {
-      fill: $primary;
+      fill: $primary !important;
     }
 
     &.icon-secondary {
-      fill: $secondary;
+      fill: $secondary !important;
     }
 
     &.icon-info {
-      fill: $info;
+      fill: $info !important;
     }
 
     &.icon-success {
-      fill: $success;
+      fill: $success !important;
     }
 
     &.icon-warning {
-      fill: $warning;
+      fill: $warning !important;
     }
 
     &.icon-danger {
-      fill: $danger;
+      fill: $danger !important;
     }
 
     & + * {


### PR DESCRIPTION
## Descrizione
Le classi per la definizione dei colori delle icone dovrebbero avere la precedenza su altri colori definiti per le icone inserite in specifici contesti.
Ad esempio non è possibile usare un'icona colore primary nel contesto dello slim header a causa della regola introdotta con la #319.


## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
