### PR TITLE
FIX colore icona in diversi contesti

### DIFF
--- a/src/scss/custom/_buttons.scss
+++ b/src/scss/custom/_buttons.scss
@@ -58,28 +58,10 @@
 
     background-color: $white;
 
-    &.rounded-primary {
-      background-color: $primary;
-    }
-
-    &.rounded-secondary {
-      background-color: $secondary;
-    }
-
-    &.rounded-info {
-      background-color: $info;
-    }
-
-    &.rounded-success {
-      background-color: $success;
-    }
-
-    &.rounded-warning {
-      background-color: $warning;
-    }
-
-    &.rounded-danger {
-      background-color: $danger;
+    @each $color, $value in $theme-colors {
+      &.rounded-#{$color} {
+        background-color: $value;
+      }
     }
 
     & + * {
@@ -90,38 +72,8 @@
   .icon {
     border: none;
 
-    width: 1.5em;
-    height: 1.5em;
-
-    fill: $primary;
-
-    &.icon-white {
-      fill: $white;
-    }
-
-    &.icon-primary {
-      fill: $primary;
-    }
-
-    &.icon-secondary {
-      fill: $secondary;
-    }
-
-    &.icon-info {
-      fill: $info;
-    }
-
-    &.icon-success {
-      fill: $success;
-    }
-
-    &.icon-warning {
-      fill: $warning;
-    }
-
-    &.icon-danger {
-      fill: $danger;
-    }
+    width: 1.2em;
+    height: 1.2em;
 
     & + * {
       margin-left: 0.25em;

--- a/src/scss/custom/_headerslim.scss
+++ b/src/scss/custom/_headerslim.scss
@@ -20,8 +20,7 @@
         height: $header-slim-icon-size;
         transition: all 0.3s;
         transform-origin: center;
-      }
-      svg {
+        // set default text color to icon
         fill: $header-slim-text-color;
       }
       &.dropdown-toggle {

--- a/src/scss/utilities/colors_vars.scss
+++ b/src/scss/utilities/colors_vars.scss
@@ -106,6 +106,8 @@ $theme-colors: map-merge(
     'danger': $danger,
     'light': $light,
     'dark': $dark,
+    'black': $black,
+    'white': $white,
     '100': $gray-100,
     '200': $gray-200,
     '300': $gray-300,

--- a/src/scss/utilities/icons.scss
+++ b/src/scss/utilities/icons.scss
@@ -35,12 +35,9 @@
   }
 }
 
+// Force color when icon-color class is explicitly used
 @each $color, $value in $theme-colors {
   .icon-#{$color} {
-    fill: $value;
+    fill: $value !important;
   }
-}
-
-.icon-white {
-  fill: $white;
 }


### PR DESCRIPTION
## Descrizione
Impostato un colore di default in ogni proprio contesto (dropdown, slimheader, btn-icon, rounded-icon)

Le classi colore per le icone, inoltre, se espressamente settate, fanno l'override del colore in ogni contesto attraverso l'uso di `!important`. In questo specifico caso è tollerabile perchè è una regola isolata che non genera modifiche involontarie ad altri contesti e lo stesso Bootstrap promuove e utilizza come tecnica nell'impostazione di colori o stili specifici.
