### PR TITLE
Aggiunge listener per gestire il refresh della label

### DIFF
--- a/src/js/plugins/forms.js
+++ b/src/js/plugins/forms.js
@@ -98,25 +98,27 @@ $(function() {
     }
   }
 
-  $('body')
-    .find(inputSelector)
-    .removeClass('valid invalid')
-    .each((index, input) => {
-      const $this = $(input)
-      const hasDefaultValue = !!$this.val()
-      const hasPlaceholder = !!$this.attr('placeholder')
-      if (hasDefaultValue || hasPlaceholder) {
-        $this
-          .siblings('label, i')
-          .css('transition', 'none')
-          .addClass('active')
-      }
+  const handleLabelPosition = () => {
+    $('body')
+      .find(inputSelector)
+      .removeClass('valid invalid')
+      .each((index, input) => {
+        const $this = $(input)
+        const hasDefaultValue = !!$this.val()
+        const hasPlaceholder = !!$this.attr('placeholder')
+        if (hasDefaultValue || hasPlaceholder) {
+          $this
+            .siblings('label, i')
+            .css('transition', 'none')
+            .addClass('active')
+        }
 
-      if (!hasDefaultValue && !hasPlaceholder) {
-        $this.siblings('label, i').removeClass('active')
-        handleLabelWidth($this)
-      }
-    })
+        if (!hasDefaultValue && !hasPlaceholder) {
+          $this.siblings('label, i').removeClass('active')
+          handleLabelWidth($this)
+        }
+      })
+  }
 
   $(window).resize(function() {
     $(inputSelector).each((index, input) => {
@@ -124,4 +126,9 @@ $(function() {
       handleLabelWidth($this)
     })
   })
+
+  handleLabelPosition()
+
+  $(document).on('changed.bs.form-control', handleLabelPosition)
+
 })


### PR DESCRIPTION
## Descrizione
Aggiunge per ora un listener (`changed.bs.form-control`) per poter sbloccare la label come segnalato nella issue #347 da @ilbassa. Vedremo poi di sistemarlo in modo più consistente.


## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

