### PR TITLE
eccezione del colore bianco per il text-emphasis-variant senza darken

### DIFF
--- a/src/scss/custom/mixins/_text-emphasis.scss
+++ b/src/scss/custom/mixins/_text-emphasis.scss
@@ -3,6 +3,9 @@
     @if $color == $warning {
       // exception for a11y
       color: darken($color, 18%) !important;
+    } @else if $color == $white {
+      // exception for white
+      color: $white !important;
     } @else {
       color: darken($color, 15%) !important;
     }


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
Impostata eccezione nel mixin per gestire il colore $white come colore bianco effettivo e non con il darken() al 15%

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [ ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
