### PR TITLE
Fix gulp prependText usage

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -115,7 +115,7 @@ gulp.task('scss-min', () => {
         specialComments: 0,
       })
     )
-    .pipe(gap.prependText(bootstrapItaliaBanner, { pkg: pkg }))
+    .pipe(gap.prependText(bootstrapItaliaBanner))
     .pipe(
       rename({
         suffix: '.min',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -155,8 +155,7 @@ gulp.task('js-min', () => {
         jqueryCheck +
         '\n' +
         jqueryVersionCheck +
-        '\n+function () {\n',
-      { pkg: pkg }
+        '\n+function () {\n'
     ))
     .pipe(gap.appendText('\n}();\n'))
     .pipe(
@@ -183,7 +182,7 @@ gulp.task('js-bundle-min', () => {
       })
     )
     .pipe(uglify())
-    .pipe(gap.prependText(bootstrapItaliaBanner, { pkg: pkg }))
+    .pipe(gap.prependText(bootstrapItaliaBanner))
     .pipe(
       rename({
         suffix: '.min',


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
I pacchetti, sia bundle che non, quando caricati generano il seguente errore (Firefox):
```
bootstrap-italia.min.js:20:22
SyntaxError: missing ] after element list
note: [ opened at line 20, column 14
```
I pacchetti contengono la stringa `[object Object]` nell'ultimo blocco `+function() { ... }`
Questo PR fissa questo problema.
Secondo la documentazione di `gulp-append-prepend`, infatti, la funzione `prependText()` come secondo parametro accetta una stringa, non un oggetto.

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
