### PR TITLE
Fix header class names

### DIFF
--- a/docs/menu-di-navigazione/header.md
+++ b/docs/menu-di-navigazione/header.md
@@ -43,8 +43,8 @@ Il **cambio lingua** è gestito con il componente [**dropdown**]({{ site.baseurl
               </a>
               <div class="link-list-wrapper collapse" id="menu1">
                 <ul class="link-list">
-                  <li><a href="#">Link 1</a></li>
-                  <li><a class="active" href="#">Link 2 Active</a></li>
+                  <li><a class="list-item" href="#">Link 1</a></li>
+                  <li><a class="list-item active" href="#">Link 2 Active</a></li>
                 </ul>
               </div>
             </nav>
@@ -171,8 +171,8 @@ Per cambiare tema all'header slim è sufficiente aggiungere la classe `theme-lig
               </a>
               <div class="link-list-wrapper collapse" id="menu2">
                 <ul class="link-list">
-                  <li><a href="#">Link 1</a></li>
-                  <li><a class="active" href="#">Link 2 Active</a></li>
+                  <li><a class="list-item" href="#">Link 1</a></li>
+                  <li><a class="list-item active" href="#">Link 2 Active</a></li>
                 </ul>
               </div>
             </nav>
@@ -946,8 +946,8 @@ Al menù di navigazione principale può essere aggiunto anche un menù di naviga
                 </a>
                 <div class="link-list-wrapper collapse" id="menu4">
                   <ul class="link-list">
-                    <li><a href="#">Link 1</a></li>
-                    <li><a class="active" href="#">Link 2 Active</a></li>
+                    <li><a class="list-item" href="#">Link 1</a></li>
+                    <li><a class="list-item active" href="#">Link 2 Active</a></li>
                   </ul>
                 </div>
               </nav>
@@ -1168,8 +1168,8 @@ Verrà creata un ombra per enfatizzarlo rispetto alla pagina in cui è contenuto
                 </a>
                 <div class="link-list-wrapper collapse" id="menu3">
                   <ul class="link-list">
-                    <li><a href="#">Link 1</a></li>
-                    <li><a class="active" href="#">Link 2 Active</a></li>
+                    <li><a class="list-item" href="#">Link 1</a></li>
+                    <li><a class="list-item active" href="#">Link 2 Active</a></li>
                   </ul>
                 </div>
               </nav>

--- a/src/scss/custom/_headerslim.scss
+++ b/src/scss/custom/_headerslim.scss
@@ -72,9 +72,11 @@
       ul.link-list {
         margin-top: $v-gap * 2;
         margin-bottom: $v-gap * 3;
-        a {
+        a.list-item {
           &.active {
-            text-decoration: underline;
+            color: $white;
+            cursor: default;
+            text-decoration: none;
           }
           &:hover:not(.active) {
             text-decoration: underline;

--- a/src/scss/custom/_headerslimtheme.scss
+++ b/src/scss/custom/_headerslimtheme.scss
@@ -62,8 +62,9 @@
           ul.link-list {
             border-left: 1px solid rgba($header-slim-theme-light-text-color, 0.2);
             border-right: 1px solid rgba($header-slim-theme-light-text-color, 0.2);
-            a {
+            a.list-item {
               &.active {
+                color: $primary;
                 border-bottom: 2px solid $header-slim-theme-light-text-color;
               }
             }


### PR DESCRIPTION
Aggiunge `list-item` per consistenza alle `link-list` presenti nello slim header.

È potenzialmente un breaking change, per cui dobbiamo capire se/come/quando mergiarlo e versionarlo.