### PR TITLE
Add proper style to focused elements

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -39,6 +39,9 @@ $small-font-size: 0.777rem !default;
 // Links
 $link-decoration: underline;
 
+// Focus
+$focus-outline-color: $orange;
+
 // Navbar
 $navbar-brand-font-size: 1rem !default;
 $navbar-toggler-border-radius: 0 !default;
@@ -355,8 +358,7 @@ $navscroll-top-box-shadow: 0 0px 30px 5px rgba(0, 0, 0, 0.05);
 $navscroll-bottom-box-shadow: 0 0px 30px 5px rgba(0, 0, 0, 0.05);
 $navscroll-primary-font-weight: 600;
 $navscroll-font-size: 1em;
-$navscroll-selection-link-left: $sidebar-dropdown-line-selection-width solid
-  $sidebar-dropdown-line-selection-color;
+$navscroll-selection-link-left: $sidebar-dropdown-line-selection-width solid $sidebar-dropdown-line-selection-color;
 $navscroll-secondary-active-color: $neutral-1-a10;
 $navscroll-links-padding: 0.8em;
 $navscroll-bg-color-desk: $white;

--- a/src/scss/custom/_form-toggles.scss
+++ b/src/scss/custom/_form-toggles.scss
@@ -17,7 +17,7 @@
     width: 0;
     height: 0;
     &:focus + .lever {
-      @extend .focus--keyboard;
+      @extend :focus;
     }
     &:focus.focus--mouse + .lever {
       @extend .focus--mouse;

--- a/src/scss/custom/_forms.scss
+++ b/src/scss/custom/_forms.scss
@@ -215,6 +215,15 @@ textarea {
       font-size: 1rem;
       user-select: none;
     }
+
+    //focus
+    &:focus + label {
+      @extend :focus;
+    }
+
+    &:focus.focus--mouse + label {
+      @extend .focus--mouse;
+    }
   }
 
   [type='checkbox'] {
@@ -294,15 +303,6 @@ textarea {
     &:disabled:checked + label::after {
       background-color: #e6e9f2;
       border-color: #e6e9f2;
-    }
-
-    //focus
-    &:focus + label {
-      @extend .focus--keyboard;
-    }
-
-    &:focus.focus--mouse + label {
-      @extend .focus--mouse;
     }
   }
 

--- a/src/scss/utilities/focus.scss
+++ b/src/scss/utilities/focus.scss
@@ -1,6 +1,6 @@
-.focus--keyboard {
-  border-color: $orange;
-  box-shadow: 0 0 6px 2px $orange;
+:focus {
+  border-color: $focus-outline-color;
+  box-shadow: 0 0 0 2px $focus-outline-color;
   outline: none;
 }
 


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
La classe `focus--keyboard` non è utilizzata per segnalare il focus da tastiera, così gli elementi che ricevono il focus hanno lo stile predefinito del browser. Questa PR assegna lo stile della classe `focus--keyboard` agli elementi che ricevono il focus.

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
