### PR TITLE
Fix Issue #403 transfer disabled on single-element Transfer

### DIFF
--- a/src/js/plugins/transfer.js
+++ b/src/js/plugins/transfer.js
@@ -92,12 +92,13 @@ $(function() {
       } else {
         disableElement(inverseButton)
       }
-    } else if (listToCheckControl.length == listToCheck.length) {
-      inputHeader.removeClass('semi-checked').prop('checked', true)
-      // controllo quale pulsante centrale disattivare
     } else {
+      if (listToCheckControl.length == listToCheck.length) {
+        inputHeader.removeClass('semi-checked').prop('checked', true)
+      } else {
+        inputHeader.addClass('semi-checked').prop('checked', false)
+      }
       // controllo quale pulsante centrale disattivare
-      inputHeader.addClass('semi-checked').prop('checked', false)
       if (scopeElControl.hasClass('source')) {
         enableElement(addButton)
       } else {


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->
Fixes #403 
Sposta il check `listToCheckControl.length == listToCheck.length` in maniera tale che non vada a influenzare l'abilitazione del pulsante(che viene abilitato sempre se c'è almeno un elemento selezionato, come dovrebbe), ma solo lo stato della checkbox nell'header.
