### PR TITLE
(docs) Aggiunti colori al componente Chips

### DIFF
--- a/docs/componenti/chips.md
+++ b/docs/componenti/chips.md
@@ -90,6 +90,18 @@ Aggiungendo la classe `.chip-lg` al contenitore si ottiene una versione più gra
 </div>
 {% endcapture %}{% include example.html content=example %}
 
+### Varianti di colore
+
+Gli stili definiti da Bootstrap Italia utilizzano un naming consistente con Bootstrap:
+
+{% capture example %}
+
+{% for color in site.data.theme-colors %}
+<div class="chip chip-{{ color.name }} chip-lg">
+  <span class="chip-label">{{ color.name | capitalize }}</span>
+</div>{% endfor %}
+{% endcapture %}{% include example.html content=example %}
+
 ## Chip Disabilitata
 
 Aggiungendo la classe `.chip-disabled` al contenitore e l'attributo `disabled` al `<button>` si ottiene una chip disabilitata.


### PR DESCRIPTION
## Descrizione
Ho modificato il file relativo alla sezione "chips" aggiungendo il display dei colori standard di Bootstrap.

Closes #402

## Checklist
- [x] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [x] La documentazione è stata aggiornata.
