### PR TITLE
Un tag "button" non può contenere un attributo "href" #416

### DIFF
--- a/docs/esempi/template-vuoto/index.html
+++ b/docs/esempi/template-vuoto/index.html
@@ -47,7 +47,7 @@ title: Template vuoto
                 </div>
               </div>
               <div class="it-access-top-wrapper">
-                <button class="btn btn-primary btn-sm" href="#" type="button">Accedi</button>
+                <a class="btn btn-primary btn-sm" href="#">Accedi</a>
               </div>
             </div>
           </div>

--- a/docs/menu-di-navigazione/header.md
+++ b/docs/menu-di-navigazione/header.md
@@ -71,7 +71,7 @@ Il **cambio lingua** è gestito con il componente [**dropdown**]({{ site.baseurl
               </div>
             </div>
             <div class="it-access-top-wrapper">
-              <button class="btn btn-primary btn-sm" href="#" type="button">Accedi</button>
+              <a class="btn btn-primary btn-sm" href="#">Accedi</a>
             </div>
           </div>
         </div>
@@ -199,7 +199,7 @@ Per cambiare tema all'header slim è sufficiente aggiungere la classe `theme-lig
               </div>
             </div>
             <div class="it-access-top-wrapper">
-              <button class="btn btn-primary btn-sm" href="#" type="button">Accedi</button>
+              <a class="btn btn-primary btn-sm" href="#">Accedi</a>
             </div>
           </div>
         </div>
@@ -974,7 +974,7 @@ Al menù di navigazione principale può essere aggiunto anche un menù di naviga
                 </div>
               </div>
               <div class="it-access-top-wrapper">
-                <button class="btn btn-primary btn-sm" href="#" type="button">Accedi</button>
+                <a class="btn btn-primary btn-sm" href="#">Accedi</a>
               </div>
             </div>
           </div>
@@ -1196,7 +1196,7 @@ Verrà creata un ombra per enfatizzarlo rispetto alla pagina in cui è contenuto
                 </div>
               </div>
               <div class="it-access-top-wrapper">
-                <button class="btn btn-primary btn-sm" href="#" type="button">Accedi</button>
+                <a class="btn btn-primary btn-sm" href="#">Accedi</a>
               </div>
             </div>
           </div>

--- a/src/scss/custom/_headerslim.scss
+++ b/src/scss/custom/_headerslim.scss
@@ -58,7 +58,8 @@
       display: flex;
       align-items: center;
       align-self: flex-start;
-      button {
+      button,  // We're keeping the button's selector here for retrocompatibility
+      div.it-access-top-wrapper a {
         background: $header-slim-button-color;
         padding-top: $header-slim-button-v-padding;
         padding-bottom: $header-slim-button-v-padding;

--- a/src/scss/custom/_headerslim.scss
+++ b/src/scss/custom/_headerslim.scss
@@ -59,7 +59,7 @@
       align-items: center;
       align-self: flex-start;
       button,  // We're keeping the button's selector here for retrocompatibility
-      div.it-access-top-wrapper > a {
+      .it-access-top-wrapper > a {
         background: $header-slim-button-color;
         padding-top: $header-slim-button-v-padding;
         padding-bottom: $header-slim-button-v-padding;

--- a/src/scss/custom/_headerslim.scss
+++ b/src/scss/custom/_headerslim.scss
@@ -59,7 +59,7 @@
       align-items: center;
       align-self: flex-start;
       button,  // We're keeping the button's selector here for retrocompatibility
-      div.it-access-top-wrapper a {
+      div.it-access-top-wrapper > a {
         background: $header-slim-button-color;
         padding-top: $header-slim-button-v-padding;
         padding-bottom: $header-slim-button-v-padding;


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->
Soluzione proposta per il fix dell'issue #416 

## Descrizione
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->
Fixes #416 
Ho modificato il codice HTML, sia nella documentazione che negli esempi, sostituendo il tag "button" con il tag "a".
Nelle linee di codice modificate ho rimosso 'type=button' (raccomandazioni W3C)
Ho modificato lo stile aggiungendo un selettore e mantenendo il vecchio selettore per retrocompatibilità.
Maggiori dettagli nel diff allegato.

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
**N.B.**. Non ho effettuato verifiche su OSX e iOS. Su linux, Android, e Windos sì. [http://arturu.it/test-bi/test/test-patch-button.html](http://arturu.it/test-bi/test/test-patch-button.html)
- [X] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [X] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
