### PR TITLE
Remove rule forcing aria-hidden behaviour

### DIFF
--- a/src/scss/custom/_timepicker.scss
+++ b/src/scss/custom/_timepicker.scss
@@ -7,10 +7,6 @@
   font-weight: bold;
 }
 
-div[aria-hidden='true'] {
-  display: none;
-}
-
 .off-screen {
   clip: rect(0, 0, 0, 0);
   overflow: hidden;


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

This PR removes a forced behaviour of `aria-hidden` which is replacing the correct browser side interpretation. 
I also found a reference to `aria-hidden` here: https://github.com/italia/bootstrap-italia/blob/58581919e8c69b3a5018e68b2619d7c44e365d43/src/scss/custom/_form-datepicker.scss#L340-L352 but I leave the last word about this to you @francescozaia 

Fixes #419 

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
