### PR TITLE
Update input.md

### DIFF
--- a/docs/form/input.md
+++ b/docs/form/input.md
@@ -72,14 +72,20 @@ In caso di necessità, è anche possibile utilizzare un ulteriore contenuto test
 {% capture callout %}
 **Associazione del testo di aiuto con gli elementi del modulo form**
 
-Il testo di aiuto deve essere esplicitamente associato agli elementi del mudulo form a cui si riferisce utilizzando l'attributo `aria-labelledby`. Ciò garantirà che le tecnologie assistive, come gli screenreader, leggano questo testo di aiuto quando l'utente avrà il focus sull'elemento.
+Il testo di aiuto deve essere esplicitamente associato agli elementi del mudulo form a cui si riferisce utilizzando l'attributo `aria-describedby`. Ciò garantirà che le tecnologie assistive, come gli screenreader, leggano questo testo di aiuto quando l'utente avrà il focus sull'elemento.
 {% endcapture %}{% include callout.html content=callout type="warning" %}
 
 {% capture example %}
 <div class="form-group">
   <label for="formGroupExampleInputWithHelp">Etichetta di esempio</label>
-  <input type="text" class="form-control" id="formGroupExampleInputWithHelp" placeholder="Testo di esempio">
-  <small class="form-text text-muted">Ulteriore testo informativo</small>
+  <input 
+    type="text" 
+    class="form-control" 
+    id="formGroupExampleInputWithHelp" 
+    placeholder="Testo di esempio" 
+    aria-describedby="formGroupExampleInputWithHelpDescription"
+  >
+  <small id="formGroupExampleInputWithHelpDescription" class="form-text text-muted">Ulteriore testo informativo</small>
 </div>
 {% endcapture %}{% include example.html content=example %}
 


### PR DESCRIPTION
Ho corretto un refuso nel testo della documentazione.
Per mettere in relazione un input con un elemento che descrive l'input stesso l'attributo da utilizzare è 'aria-describedby' e non 'aria-labelledby'

<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->
Ho modificato l'attributo 'aria-labelledby' con 'aria-describedby' e aggiunto il codice di esempio.
Riferimenti:
- [https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA1](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA1)
- [https://www.accessibilityoz.com/videos/aria-labelledby-vs-aria-describedby-vs-aria-label/](https://www.accessibilityoz.com/videos/aria-labelledby-vs-aria-describedby-vs-aria-label/)

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
N.B Il [D.M. 8/2015 - Allegato A](https://www.agid.gov.it/dm-8-luglio-2005-allegato-A#requisito1) fa riferimento al criterio "[Riferimento WCAG 2.0: Criterio di successo 1.1.1](https://www.w3.org/Translations/WCAG20-it/#text-equiv)" invece ho usato i riferimenti WCAG 2.1 (2018)
- [x ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
