### PR TITLE
Fixed Thumbnav on Firefox, closes #465

### DIFF
--- a/src/scss/custom/_thumbnav.scss
+++ b/src/scss/custom/_thumbnav.scss
@@ -8,6 +8,19 @@
   &.thumb-nav-vertical {
     flex-direction: column;
     align-items: baseline;
+    li {
+      height: 160px;
+      width: auto;
+    }
+    .thumb-nav-resizer {
+      width: auto;
+      height: 100%;
+    }
+    &.thumb-nav-small {
+      li {
+        height: 80px;
+      }
+    }
   }
 
   // fixed version
@@ -124,20 +137,19 @@
     position: relative;
     list-style-type: none;
     margin: 8px;
+    width: 240px;
+    flex: 0 1 auto;
   }
 
   // invisible resizer image
   .thumb-nav-resizer {
     width: 100%;
     height: auto;
-    max-width: 240px;
-    max-height: 160px;
     visibility: hidden;
   }
   &.thumb-nav-small {
-    .thumb-nav-resizer {
-      max-width: 120px;
-      max-height: 80px;
+    li {
+      width: 120px;
     }
   }
 


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->
Fixed the flexbox CSS that was not working on Firefox, see the issue #465 

## Descrizione
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->
The layout engine could not infer correctly the dimensions of the thumbnails. So I tweaked a bit the CSS in such a way that the browser has all the box model's information to guess reliably the sizes. Fixes #465 

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [X] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [X] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [X] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [X] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata. _(Not necessary)_

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
