### PR TITLE
Fix: feedback html required non visibile

### DIFF
--- a/src/scss/custom/_forms.scss
+++ b/src/scss/custom/_forms.scss
@@ -203,7 +203,7 @@ textarea {
   [type='checkbox'],
   [type='radio'] {
     position: absolute;
-    left: -9999px;
+    opacity: 0;
 
     + label {
       position: relative;


### PR DESCRIPTION
## Descrizione
Spostare a sinistra l'elemento per farlo sparire dallo schermo rende impossibile vedere eventuali feedback del browser (ad esempio se il campo è required ma non viene spuntato). Impostando usando `opacity: 0` al posto di `left: -9999px` l'elemento non si vede ma rimane nella posizione originale, consentendo di vedere il feedback.

## Checklist
- [x] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo. **Al momento non riesco a testare su Internet Explorer ma opacity è completamente [supportato](https://caniuse.com/?search=opacity) da IE 9+**
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [x] La documentazione è stata aggiornata.
