### PR TITLE
Point links to Bootstrap 4.6 docs

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 <!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
 - [ ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
 - [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
-- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.5/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
+- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.6/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
 - [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
 - [ ] La documentazione è stata aggiornata.
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 <!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
 - [ ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
 - [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
-- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
+- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.5/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
 - [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
 - [ ] La documentazione è stata aggiornata.
 

--- a/README.EN.md
+++ b/README.EN.md
@@ -6,7 +6,7 @@
 
 *Read this in other languages: [Italiano](README.md).*
 
-Bootstrap Italia is a [Bootstrap 4](https://getbootstrap.com/docs/) theme to create responsive web apps to make Italian public digital services consistent, accessible and simple to use.
+Bootstrap Italia is a [Bootstrap 4](https://getbootstrap.com/docs/4.5/getting-started/introduction/) theme to create responsive web apps to make Italian public digital services consistent, accessible and simple to use.
 
 Bootstrap Italia inherits components, mixins, grid system, and anything else from Bootstrap 4, customising them accordingly to the [Italian guidelines for designing public digital services](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
 

--- a/README.EN.md
+++ b/README.EN.md
@@ -6,7 +6,7 @@
 
 *Read this in other languages: [Italiano](README.md).*
 
-Bootstrap Italia is a [Bootstrap 4](https://getbootstrap.com/docs/4.5/getting-started/introduction/) theme to create responsive web apps to make Italian public digital services consistent, accessible and simple to use.
+Bootstrap Italia is a [Bootstrap 4](https://getbootstrap.com/docs/4.6/getting-started/introduction/) theme to create responsive web apps to make Italian public digital services consistent, accessible and simple to use.
 
 Bootstrap Italia inherits components, mixins, grid system, and anything else from Bootstrap 4, customising them accordingly to the [Italian guidelines for designing public digital services](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 *Read this in other languages: [English](README.EN.md).*
 
-Bootstrap Italia è un tema basato su [Bootstrap 4](https://getbootstrap.com/docs/) per la creazione di applicazioni responsive, mobile-first per il web.
+Bootstrap Italia è un tema basato su [Bootstrap 4](https://getbootstrap.com/docs/4.5/getting-started/introduction/) per la creazione di applicazioni responsive, mobile-first per il web.
 
 Bootstrap Italia eredita tutte le funzionalità, componenti, mixins, grid system, ed altro già presenti in Bootstrap 4, e le personalizza secondo le [linee guida di design per i servizi web delle Pubbliche Amministrazioni](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 *Read this in other languages: [English](README.EN.md).*
 
-Bootstrap Italia è un tema basato su [Bootstrap 4](https://getbootstrap.com/docs/4.5/getting-started/introduction/) per la creazione di applicazioni responsive, mobile-first per il web.
+Bootstrap Italia è un tema basato su [Bootstrap 4](https://getbootstrap.com/docs/4.6/getting-started/introduction/) per la creazione di applicazioni responsive, mobile-first per il web.
 
 Bootstrap Italia eredita tutte le funzionalità, componenti, mixins, grid system, ed altro già presenti in Bootstrap 4, e le personalizza secondo le [linee guida di design per i servizi web delle Pubbliche Amministrazioni](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
 

--- a/_data/examples.yml
+++ b/_data/examples.yml
@@ -70,4 +70,4 @@
 #      description: 'Un esempio di Home Page'
 #      status: work in progress
 - category: Esempi dal sito ufficiale di Bootstrap 4
-  description: La documentazione di Bootstrap 4 contiene <a href="https://getbootstrap.com/docs/4.3/examples/" target="_blank">molti altri esempi</a> che possono risultare utili nell'utilizzo della libreria.
+  description: La documentazione di Bootstrap 4 contiene <a href="https://getbootstrap.com/docs/4.5/examples/" target="_blank">molti altri esempi</a> che possono risultare utili nell'utilizzo della libreria.

--- a/_data/examples.yml
+++ b/_data/examples.yml
@@ -70,4 +70,4 @@
 #      description: 'Un esempio di Home Page'
 #      status: work in progress
 - category: Esempi dal sito ufficiale di Bootstrap 4
-  description: La documentazione di Bootstrap 4 contiene <a href="https://getbootstrap.com/docs/4.5/examples/" target="_blank">molti altri esempi</a> che possono risultare utili nell'utilizzo della libreria.
+  description: La documentazione di Bootstrap 4 contiene <a href="https://getbootstrap.com/docs/4.6/examples/" target="_blank">molti altri esempi</a> che possono risultare utili nell'utilizzo della libreria.

--- a/_includes/callout-danger-async-methods.md
+++ b/_includes/callout-danger-async-methods.md
@@ -3,5 +3,5 @@
 
 Tutti i metodi API sono **asincroni** e avviano una **transizione**. Ritornano al chiamante non appena viene avviata la transizione ma **prima che termini**. Inoltre, una chiamata al metodo su un **componente in transizione verrà ignorata**.
 
-Per maggiori informazioni consulta la [documentazione Javascript di Bootstrap](https://getbootstrap.com/docs/4.0/getting-started/javascript/) (in inglese).
+Per maggiori informazioni consulta la [documentazione Javascript di Bootstrap](https://getbootstrap.com/docs/4.5/getting-started/javascript/) (in inglese).
 {% endcapture %}{% include callout.html content=callout type="info" %}

--- a/_includes/callout-danger-async-methods.md
+++ b/_includes/callout-danger-async-methods.md
@@ -3,5 +3,5 @@
 
 Tutti i metodi API sono **asincroni** e avviano una **transizione**. Ritornano al chiamante non appena viene avviata la transizione ma **prima che termini**. Inoltre, una chiamata al metodo su un **componente in transizione verrà ignorata**.
 
-Per maggiori informazioni consulta la [documentazione Javascript di Bootstrap](https://getbootstrap.com/docs/4.5/getting-started/javascript/) (in inglese).
+Per maggiori informazioni consulta la [documentazione Javascript di Bootstrap](https://getbootstrap.com/docs/4.6/getting-started/javascript/) (in inglese).
 {% endcapture %}{% include callout.html content=callout type="info" %}


### PR DESCRIPTION
## Descrizione
Aggiornati i link alla documentazione di Bootstrap in modo che puntino alla versione corretta (4.5)

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] La documentazione è stata aggiornata.
