### PR TITLE
fix: cleanup baseurl configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,8 +8,6 @@ permalink:      pretty
 
 source:         "."
 destination:    "./_site"
-baseurl:        ""
-url:            "http://localhost:4000"
 encoding:       UTF-8
 exclude:
   - .git/

--- a/_config_production.yml
+++ b/_config_production.yml
@@ -1,3 +1,1 @@
-environment:    "production"
-url:            "https://italia.github.io/bootstrap-italia"
 baseurl:        "/bootstrap-italia"

--- a/_includes/favicons.html
+++ b/_includes/favicons.html
@@ -4,8 +4,6 @@
 <link rel="icon" href="{{ site.baseurl }}/docs/assets/img/favicons/favicon-16x16.png" sizes="16x16" type="image/png">
 <link rel="mask-icon" href="{{ site.baseurl }}/docs/assets/img/favicons/safari-pinned-tab.svg" color="#0066CC">
 <link rel="apple-touch-icon" href="{{ site.baseurl }}/docs/assets/img/favicons/apple-touch-icon.png">
-{% if site.environment == "production" %}
-<link rel="manifest" href="{{ site.baseurl }}/docs/assets/img/favicons/manifest.webmanifest">
-<meta name="msapplication-config" content="{{ site.baseurl }}/docs/assets/img/favicons/browserconfig.xml">
-{% endif %}
+<link rel="manifest" href="{{ site.baseurl }}/site.webmanifest">
+<meta name="msapplication-config" content="{{ site.baseurl }}/browserconfig.xml">
 <meta name="theme-color" content="#0066CC">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -27,7 +27,7 @@
 {% include favicons.html %}
 {% include social.html %}
 
-{% if site.environment == "production" %}
+{% if jekyll.environment == "production" %}
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script>
 // Disabilita tracciamento se il cookie cookies_consent non esiste

--- a/browserconfig.xml
+++ b/browserconfig.xml
@@ -1,8 +1,10 @@
+---
+---
 <?xml version="1.0" encoding="utf-8"?>
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="/bootstrap-italia/docs/assets/img/favicons/mstile-150x150.png"/>
+          <square150x150logo src="{{ site.baseurl }}/docs/assets/img/favicons/mstile-150x150.png"/>
             <TileColor>#0066CC</TileColor>
         </tile>
     </msapplication>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "gulp build",
     "documentation-build": "bundle exec jekyll build",
     "documentation-serve": "bundle exec jekyll serve",
-    "documentation-deploy-to-gh-pages": "bundle exec jekyll build --config _config.yml,_config_production.yml && gh-pages -d _site -m 'Update documentation [ci skip]'",
+    "documentation-deploy-to-gh-pages": "JEKYLL_ENV=production bundle exec jekyll build --config _config.yml,_config_production.yml && gh-pages -d _site -m 'Update documentation [ci skip]'",
     "release": "node scripts/release",
     "bump-major": "npm version major -m \"Release %s\"",
     "bump-minor": "npm version minor -m \"Release %s\"",

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,3 +1,5 @@
+---
+---
 {
   "name": "Bootstrap Italia",
   "short_name": "BS Italia",
@@ -8,12 +10,12 @@
   "description": "Bootstrap Italia è un tema open-source basato su Bootstrap 4 per la creazione di applicazioni responsive, mobile-first per il web.",
   "icons": [
     {
-      "src": "/bootstrap-italia/docs/assets/img/favicons/android-chrome-192x192.png",
+      "src": "{{ site.baseurl }}/docs/assets/img/favicons/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/bootstrap-italia/docs/assets/img/favicons/android-chrome-512x512.png",
+      "src": "{{ site.baseurl }}/docs/assets/img/favicons/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
* Remove superfluous configuration
* Make browserconfig.xml and site.webmanifest respect baseurl
* Use the JEKYLL_ENV variable to set the environment, as it's the
  standard method to do it

Fix #571.