### PR TITLE
Checkbox/radio button's required HTML feedback not visible

### DIFF
--- a/src/scss/custom/_forms.scss
+++ b/src/scss/custom/_forms.scss
@@ -204,6 +204,10 @@ textarea {
   [type='radio'] {
     position: absolute;
     opacity: 0;
+    left: 9px;
+    top: 9px;
+    margin-left: 0;
+    margin-top: 0;
 
     + label {
       position: relative;

--- a/src/scss/custom/_forms.scss
+++ b/src/scss/custom/_forms.scss
@@ -203,7 +203,7 @@ textarea {
   [type='checkbox'],
   [type='radio'] {
     position: absolute;
-    left: -9999px;
+    opacity: 0;
 
     + label {
       position: relative;


### PR DESCRIPTION
I made a new PR since the previous one (#557) was uncorrectly from fork's master to upstream's master. I also applied the suggested changes.

## Descrizione
Moving the actual HTML checkbox/radio button to the left to make it disappear from the screen leads the browser's native feedback box to also disappear (for example if the field is marked as required but the checkbox is not ticked). Setting `opacity: 0` instead of `left: -9999px` makes the native checkbox/radio button disappear without moving it outside of the screen so the feedback can be seen.

@gpeirolo also kindly suggested to move the invisible cbox/rb a bit to better align the browser's feedback box.

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.6/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo. **Al momento non riesco a testare su Internet Explorer ma opacity è completamente supportato da IE 9+**
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
