### PR TITLE
Update _breadcrumb.scss

### DIFF
--- a/docs/menu-di-navigazione/breadcrumbs.md
+++ b/docs/menu-di-navigazione/breadcrumbs.md
@@ -53,11 +53,13 @@ Per aggiungere un icona all'elemento breadcrumb è sufficiente inserire l'SVG co
 
 ### Su sfondo scuro
 
-Per la versione su sfondo scuro delle breadcrumbs è sufficiente aggiungere al tag `<ol class="breadcrumb">` la classe `.dark`
+Per la versione su sfondo scuro delle breadcrumbs è sufficiente aggiungere al tag `<ol class="breadcrumb">` la classe `.dark`.
+
+Quando la versione su sfondo scuro viene utilizzata su un fondo di colore differente aggiungere la classe di spaziatura `px-3` al `<ol class="breadcrumb dark">` per creare un padding laterale.
 
 {% capture example %}
 <nav class="breadcrumb-container" aria-label="breadcrumb">
-  <ol class="breadcrumb dark">
+  <ol class="breadcrumb dark px-3">
     <li class="breadcrumb-item"><a href="#">Home</a><span class="separator">/</span></li>
     <li class="breadcrumb-item"><a href="#">Subsection</a><span class="separator">/</span></li>
     <li class="breadcrumb-item active" aria-current="page">Current section</li>
@@ -66,7 +68,7 @@ Per la versione su sfondo scuro delle breadcrumbs è sufficiente aggiungere al t
 
 <hr>
 <nav class="breadcrumb-container" aria-label="breadcrumb">
-  <ol class="breadcrumb dark">
+  <ol class="breadcrumb dark px-3">
     <li class="breadcrumb-item"><svg class="icon icon-sm icon-white align-top mr-1" aria-hidden="true"><use xlink:href="{{ site.baseurl }}/dist/svg/sprite.svg#it-link"></use></svg><a href="#">Home</a><span class="separator">/</span></li>
     <li class="breadcrumb-item"><svg class="icon icon-sm icon-white align-top mr-1" aria-hidden="true"><use xlink:href="{{ site.baseurl }}/dist/svg/sprite.svg#it-link"></use></svg><a href="#">Subsection</a><span class="separator">/</span></li>
     <li class="breadcrumb-item active" aria-current="page">Current section</li>

--- a/src/scss/custom/_breadcrumb.scss
+++ b/src/scss/custom/_breadcrumb.scss
@@ -29,6 +29,7 @@
     // dark version
     &.dark {
       background: $breadcrumb-bg-dark;
+      padding: $breadcrumb-padding;
       color: $breadcrumb-link-color-dark;
       .breadcrumb-item {
         a {

--- a/src/scss/custom/_breadcrumb.scss
+++ b/src/scss/custom/_breadcrumb.scss
@@ -29,7 +29,6 @@
     // dark version
     &.dark {
       background: $breadcrumb-bg-dark;
-      padding: $breadcrumb-padding;
       color: $breadcrumb-link-color-dark;
       .breadcrumb-item {
         a {


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->
Nella versione dark gli elementi della breadcrumb sono attaccati al bordo sinistro del contenitore (https://italia.github.io/bootstrap-italia/docs/menu-di-navigazione/breadcrumbs/#su-sfondo-scuro), propongo di aggiungere un padding nella versione dark per staccare un po' gli elementi dal bordo. 

## Descrizione
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

Per fare la modifica ho inserito una linea di codice nella variante dark, ho inserito un paddig su tutti i lati utilizzato la varibile $breadcrumb-padding.

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
