### PR TITLE
docs(a11y): skiplinks tab navigation instructions for macos

### DIFF
--- a/docs/menu-di-navigazione/skiplinks.md
+++ b/docs/menu-di-navigazione/skiplinks.md
@@ -22,4 +22,31 @@ Per attivare la funzionalità si digita da tastiera il tasto: **TAB**.
 </div>
 {% endcapture %}{% include example.html content=example %}
     
+{% capture callout %}
+#### Visualizzazione degli Skiplinks su macOS
 
+##### Chrome
+Per attivare la funzionalità si digita da tastiera il tasto: **TAB**. 
+
+##### Safari 
+Per attivare la navigazione via **TAB** è necessario:
+
+1. Aprire il menù Safari > Preferenze
+2. Cliccare sulla tab Avanzate
+3. Selezionare “Premi tabulatore per evidenziare tutti gli elementi della pagina web”.
+
+Alternativamente è possibile navigare gli elementi usando **opzione+TAB**
+
+##### Firefox
+Le impostazioni  di default di macOS non consentono la navigazione di tutti gli elementi interattivi di un sito con l'uso del pulsante TAB.
+Per attivare questa modalità è necessario modificare le preferenze di sistema come segue:
+
+1. Aprire il Menu Apple > Preferenze di Sistema, quindi fare clic su Tastiera.
+2. Fare clic su Abbreviazioni.
+3. Nella parte inferiore della finestra delle preferenze, selezionare “Usa la navigazione da tastiera per spostare la selezione tra i controlli”.
+
+Una volta selezionata questa opzione gli skiplinks saranno attivabili su Firefox con il pulsante **TAB**.
+
+Vedi anche la [guida ufficiale di Apple](https://support.apple.com/it-it/HT204434).
+
+{% endcapture %}{% include callout.html content=callout type="warning" %}


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
Fixes #543 

Aggiunta documentazione relativa all'utilizzo della navigazione delle pagine con tasto TAB in macOS per:
- Chrome
- Safari
- Firefox

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [ ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.6/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
