### PR TITLE
fix(core,a11y): select label with for attribute instead of siblings.

### DIFF
--- a/src/js/plugins/forms.js
+++ b/src/js/plugins/forms.js
@@ -13,7 +13,7 @@ $(function() {
   const inputFileSelector = 'input[type="file"]'
 
   const handleLabelWidth = $input => {
-    const labelsForInput = $input.siblings('label:not(.active)')
+    const labelsForInput = $("label[for='" + $input.attr('id') + "']:not(.active)")
     if (labelsForInput && labelsForInput.length) {
       let labelWidth =
         labelsForInput[0].offsetWidth > $input[0].offsetWidth - 20
@@ -26,8 +26,9 @@ $(function() {
   $(document)
     .on('focus', inputSelector, e => {
       const $this = $(e.target)
-      $this.siblings('label, i').addClass('active')
-      const labelsForInput = $this.siblings('label')
+      const labelSelector = "label[for='" + $this.attr('id') + "']"
+      $(labelSelector).addClass('active')
+      const labelsForInput = $(labelSelector)
       if (labelsForInput && labelsForInput.length) {
         $(labelsForInput[0]).css('width', 'auto')
       }
@@ -38,7 +39,7 @@ $(function() {
       const noPlaceholder = !$this.attr('placeholder')
 
       if (noValue && noPlaceholder) {
-        $this.siblings('label, i').removeClass('active')
+        $("label[for='" + $this.attr('id') + "']").removeClass('active')
         handleLabelWidth($this)
       }
     })
@@ -49,7 +50,7 @@ $(function() {
     })
     .on('blur', inputFileSelector, e => {
       const $this = $(e.target)
-      $this.siblings('label').addClass('active')
+      $("label[for='" + $this.attr('id') + "']").addClass('active')
     })
     .on('change', inputFileSelector, e => {
       const $this = $(e.target)
@@ -65,11 +66,11 @@ $(function() {
       if (numFiles > 1) {
         multi = numFiles + ' file da caricare: '
       }
-      $this.siblings('.form-file-name').text(multi + nomiFiles)
+      $("label[for='" + $this.attr('id') + "']label[class='form-file-name']").text(multi + nomiFiles)
     })
 
   const updateTextFields = $input => {
-    const $labelAndIcon = $input.siblings('label, i')
+    const $labelAndIcon = $("label[for='" + $input.attr('id') + "']")
     const hasValue = $input.val().length
     const hasPlaceholder = !!$input.attr('placeholder')
     if (hasValue || hasPlaceholder) {
@@ -107,14 +108,13 @@ $(function() {
         const hasDefaultValue = !!$this.val()
         const hasPlaceholder = !!$this.attr('placeholder')
         if (hasDefaultValue || hasPlaceholder) {
-          $this
-            .siblings('label, i')
+          $("label[for='" + $this.attr('id') + "']")
             .css('transition', 'none')
             .addClass('active')
         }
 
         if (!hasDefaultValue && !hasPlaceholder) {
-          $this.siblings('label, i').removeClass('active')
+          $("label[for='" + $this.attr('id') + "']").removeClass('active')
           handleLabelWidth($this)
         }
       })


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

Quando un campo di input ha il focus la label si sposta verso l'alto, questo comportamento è implementato in form.js e la selezione della label avviene con il metodo `siblings()`. Ho cambiato il metodo di selezione utilizzando l'associazione `for/id`.

Propongo la discussione di questo cambiamento in quanto penso che sia necessario sotto due aspetti:
- nei CMS alcune volte il campo `input` è racchiuso dentro a dei campi `div` - necessario per editor di testo, campi particolari, ecc - quindi viene meno la selezione come "fratelli" sullo stesso nodo;
- la selezione della label attraverso l'associazione `for/id` copre una casistica molto più ampia della selezione tra nodi fratelli.

**Nota**: Questa modifica potrebbe essere problematica per le applicazioni che ancora non associano la label al campo input (non accessibili praticamente).

## Descrizione
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

Ho sostituito la selezione fatta attraverso il metodo `siblings()` con un selettore tipo `$('selettore')`

Ho pubblicato in anteprima il risultato a questo indirizzo https://bi-branch-formjs.arturu.it/docs/form/input/

Questo fix viene usato da 2 anni (v0.4) nel tema drupal https://git.drupalcode.org/project/bootstrap_italia/-/blob/8.x-0.4/src/js/custom/forms.js e fino ad ora non abbiamo riscontrato particolari problematiche.


## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.6/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
