### PR TITLE
fix(core): cutted label on input elements

### DIFF
--- a/src/js/plugins/forms.js
+++ b/src/js/plugins/forms.js
@@ -16,6 +16,7 @@ $(function() {
     const labelsForInput = $input.siblings('label:not(.active)')
     if (labelsForInput && labelsForInput.length) {
       let labelWidth =
+        labelsForInput[0].offsetWidth > 0 && $input[0].offsetWidth > 0 &&
         labelsForInput[0].offsetWidth > $input[0].offsetWidth - 20
           ? $input[0].offsetWidth
           : 'auto'


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

Fixes #526, #429, #450
La label risultava tagliata se inserita all'interno di un tab non attivo di default o una modale.

## Descrizione
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.6/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
