### PR TITLE
fix(core): focus behaviour

### DIFF
--- a/src/scss/utilities/focus.scss
+++ b/src/scss/utilities/focus.scss
@@ -1,15 +1,15 @@
-:focus {
-  border-color: $focus-outline-color;
-  box-shadow: 0 0 0 2px $focus-outline-color;
-  outline: none;
+:focus:not(.focus--mouse){
+  border-color: $focus-outline-color !important;
+  box-shadow: 0 0 0 2px $focus-outline-color !important;
+  outline: none !important;
 }
 
 [tabindex="-1"]:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.focus--mouse {
-  border-color: inherit;
-  box-shadow: none;
-  outline: none;
+.focus--mouse:not(.btn) {
+  border-color: inherit !important;
+  box-shadow: none !important;
+  outline: none !important;
 }


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->
Questa PR fixes #518

## Descrizione
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->
Ora, tutti gli elementi raggiunti tramite tab risultano bordati di arancione.
I bottoni se cliccati, mantengono il focus originale di bootstrap.

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [X] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [X] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [X] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.6/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [X] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
