### PR TITLE
docs: dropdown examples and side navigation fix

### DIFF
--- a/docs/componenti/dropdown.md
+++ b/docs/componenti/dropdown.md
@@ -82,6 +82,21 @@ Ovviamente, funzionano anche [tutte le varianti]({{ site.baseurl }}/docs/compone
     </div>
   </div>
 </div>
+<div class="btn-group">
+  <button type="button" class="btn btn-danger dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    Apri dropdown
+    <svg class="icon-expand icon icon-sm icon-light"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-expand"></use></svg>
+  </button>
+  <div class="dropdown-menu">
+    <div class="link-list-wrapper">
+      <ul class="link-list">
+        <li><a class="list-item" href="#"><span>Azione 1</span></a></li>
+        <li><a class="list-item" href="#"><span>Azione 2</span></a></li>
+        <li><a class="list-item" href="#"><span>Azione 3</span></a></li>
+      </ul>
+    </div>
+  </div>
+</div>
 {% endcapture %}{% include example.html content=example %}
 
 ### Dropdown link
@@ -151,7 +166,7 @@ All'interno del menu dropdown possono essere inseriti header e separatori.
   <div class="link-list-wrapper">
     <ul class="link-list">
       <li>
-        <h3 id="esempio-header-1">Esempio Header 1</h3>
+        <h3 id="esempio-header-1" class="no_toc">Esempio Header 1</h3>
       </li>
       <li><a class="list-item" href="#"><span>Azione 1</span></a></li>
       <li><a class="list-item" href="#"><span>Azione 2</span></a></li>
@@ -270,7 +285,7 @@ Aggiungendo la classe`.dark` al dropdown menu si ottiene una versione in negativ
   <div class="link-list-wrapper">
     <ul class="link-list">
       <li>
-        <h3 id="esempio-header-2">Esempio Header 2</h3>
+        <h3 id="esempio-header-2" class="no_toc">Esempio Header 2</h3>
       </li>
       <li>
         <a class="list-item right-icon active" href="#">


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
Fixes #542 

Aggiunto esempio dropdown con bottone `.btn-danger`.
Aggiunta classe `.no-toc` a due h3 degli esempi per escluderli dal menù di navigazione laterale.

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [ ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.6/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
