### PR TITLE
fix(core): set mobile navbar z-index to 100 so it always stays on top

### DIFF
--- a/src/scss/custom/_navigation.scss
+++ b/src/scss/custom/_navigation.scss
@@ -31,7 +31,7 @@
     right: 0;
     left: 0;
     bottom: 0;
-    z-index: 1;
+    z-index: 100;
     display: none;
     width: 100%; //-occupa sempre tutta lo spazio orizzontale disponibile
 


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
Fixes #525

La soluzione proposta avrebbe risolto il problema solo per la paginazione.
Bootstrap utilizza z-index specifici (1,2,3) per stati normail, hover o attivi di qualsiasi bottone.

![525-zindex](https://user-images.githubusercontent.com/38532526/150535103-892d2575-30f0-4c52-85b5-5004e5312294.png)

Ho impostato lo z-index del menù aperto mobile a 100 in modo che si trovi sempre sopra agli elementi di pagina.

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [ ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.6/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida
-docs/it/stabile/doc/service-design/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
