### PR TITLE
fix(core): css solution for safari masonry bug plus ie11 fix

### DIFF
--- a/src/scss/custom/_gridlist.scss
+++ b/src/scss/custom/_gridlist.scss
@@ -93,12 +93,20 @@
   }
   // masonry
   &.it-masonry {
+    &.it-image-label-grid {
+      div[class^=col-] {
+        padding-bottom: 0;
+      }
+    }
     .card-columns {
       margin-left: -(($grid-list-text-gap * 2) + ($grid-list-default-gap * 2));
       margin-right: -(($grid-list-text-gap * 2) + ($grid-list-default-gap * 2));
       column-gap: 0;
       .it-grid-item-wrapper {
         break-inside: avoid-column;
+        display: inline-block;
+        width: 100%;
+        margin-bottom: 16px;
         .img-responsive {
           padding-bottom: initial;
           height: auto;
@@ -118,6 +126,12 @@
     }
   }
 }
+
+//fix masonry ie11
+_:-ms-fullscreen, .it-grid-list-wrapper.it-masonry .card-columns .it-grid-item-wrapper .img-responsive {
+  padding-bottom: 0;
+}
+
 //Tablet horizontal / small desktop
 @media (min-width: #{map-get($grid-breakpoints, lg)}) {
   // grid default

--- a/src/scss/custom/_gridlist.scss
+++ b/src/scss/custom/_gridlist.scss
@@ -94,7 +94,7 @@
   // masonry
   &.it-masonry {
     &.it-image-label-grid {
-      div[class^=col-] {
+      div[class^='col-'] {
         padding-bottom: 0;
       }
     }
@@ -128,9 +128,12 @@
 }
 
 //fix masonry ie11
-_:-ms-fullscreen, .it-grid-list-wrapper.it-masonry .card-columns .it-grid-item-wrapper .img-responsive {
+/* stylelint-disable */
+_:-ms-fullscreen,
+.it-grid-list-wrapper.it-masonry .card-columns .it-grid-item-wrapper .img-responsive {
   padding-bottom: 0;
 }
+/* stylelint-enable */
 
 //Tablet horizontal / small desktop
 @media (min-width: #{map-get($grid-breakpoints, lg)}) {


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
Fixes #453 

Modificato il CSS per risolvere bug di rendering di Safari.
Fix specifico per l'altezza delle immagini in IE11.
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.6/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
