### PR TITLE
docs: rimozione icona chiudi da toolbar

### DIFF
--- a/docs/menu-di-navigazione/toolbar.md
+++ b/docs/menu-di-navigazione/toolbar.md
@@ -316,8 +316,8 @@ Nella versione media i Badge non contengono numeri ma possono essere usati come 
     </li>
     <li>
       <a href="#" class="disabled" disabled aria-disabled="true">
-        <span class="sr-only">chiudi</span>
-        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-close"></use></svg>
+        <span class="sr-only">download</span>
+        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-download"></use></svg>
       </a>
     </li>
   </ul>
@@ -372,8 +372,8 @@ Nella versione piccola i Badge non contengono numeri ma possono essere usati com
     </li>
     <li>
       <a href="#" class="disabled" disabled aria-disabled="true">
-        <span class="sr-only">chiudi</span>
-        <svg class="icon icon-sm"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-close"></use></svg>
+        <span class="sr-only">download</span>
+        <svg class="icon icon-sm"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-download"></use></svg>
       </a>
     </li>
   </ul>
@@ -469,9 +469,9 @@ All'interno della Toolbar è possibile implementare dei bottoni dropdown con rel
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton5">
           <div class="link-list-wrapper">
             <ul class="link-list">
-              <li><a class="list-item left-icon" href="#"><svg class="icon mr-2" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-link"></use></svg><span>Label</span></a></li>
-              <li><a class="list-item left-icon" href="#"><svg class="icon mr-2" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-mail"></use></svg><span>Label</span></a></li>
-              <li><a class="list-item left-icon" href="#"><svg class="icon mr-2" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-settings"></use></svg><span>Label</span></a></li>
+              <li><a class="list-item icon-left" href="#"><svg class="icon mr-2" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-link"></use></svg><span>Label</span></a></li>
+              <li><a class="list-item icon-left" href="#"><svg class="icon mr-2" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-mail"></use></svg><span>Label</span></a></li>
+              <li><a class="list-item icon-left" href="#"><svg class="icon mr-2" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-settings"></use></svg><span>Label</span></a></li>
             </ul>
           </div>
         </div>
@@ -589,9 +589,9 @@ All'interno della Toolbar è possibile implementare dei bottoni dropdown con rel
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton6-med">
           <div class="link-list-wrapper">
             <ul class="link-list">
-              <li><a class="list-item left-icon" href="#"><svg class="icon mr-2 left" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-link"></use></svg><span>Label</span></a></li>
-              <li><a class="list-item left-icon" href="#"><svg class="icon mr-2 left" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-mail"></use></svg><span>Label</span></a></li>
-              <li><a class="list-item left-icon" href="#"><svg class="icon mr-2 left" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-settings"></use></svg><span>Label</span></a></li>
+              <li><a class="list-item icon-left" href="#"><svg class="icon mr-2" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-link"></use></svg><span>Label</span></a></li>
+              <li><a class="list-item icon-left" href="#"><svg class="icon mr-2" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-mail"></use></svg><span>Label</span></a></li>
+              <li><a class="list-item icon-left" href="#"><svg class="icon mr-2" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-settings"></use></svg><span>Label</span></a></li>
             </ul>
           </div>
         </div>
@@ -831,8 +831,8 @@ Applicando una classe aggiuntiva `.toolbar-vertical` alla Toolbar gli elementi v
     </li>
     <li>
       <a href="#" class="disabled" disabled aria-disabled="true">
-        <span class="sr-only">chiudi</span>
-        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-close"></use></svg>
+        <span class="sr-only">download</span>
+        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-download"></use></svg>
       </a>
     </li>
   </ul>
@@ -897,8 +897,8 @@ Applicando una classe aggiuntiva `.toolbar-vertical` alla Toolbar gli elementi v
     </li>
     <li>
       <a href="#" class="disabled" disabled aria-disabled="true">
-        <span class="sr-only">chiudi</span>
-        <svg class="icon icon-sm"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-close"></use></svg>
+        <span class="sr-only">download</span>
+        <svg class="icon icon-sm"><use href="{{ site.baseurl }}/dist/svg/sprite.svg#it-download"></use></svg>
       </a>
     </li>
   </ul>


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
Fix #569
<!--- Descrivi le modifiche in dettaglio -->
Rimossa l'icona chiudi disabilitata per evitare confusione.
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [X] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [X] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [X] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.6/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [X] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [X] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
