### PR TITLE
fix(core): specific selector for header slim dropdown

### DIFF
--- a/src/scss/custom/_headerslim.scss
+++ b/src/scss/custom/_headerslim.scss
@@ -30,7 +30,7 @@
         display: flex;
         align-items: center;
         &[aria-expanded='true'] {
-          .icon {
+          & > .icon:last-of-type {
             transform: scaleY(-1);
           }
         }
@@ -41,7 +41,7 @@
         display: block;
         text-decoration: none;
         &[aria-expanded='true'] {
-          .icon {
+          & > .icon:last-of-type {
             transform: scaleY(-1);
           }
         }


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Fixes #435 

Inserito un selettore CSS più specifico per l'icona caret che indica l'apertura del dropdown.
Ora è possibile inserire icone nel dropdown senza che queste vengano ribaltate all'apertura.

![dropdown](https://user-images.githubusercontent.com/38532526/151336185-22a2f187-b65c-4799-a42a-4fcbfee4a5e6.jpg)

![opener](https://user-images.githubusercontent.com/38532526/151336191-5805a0c8-a570-4e7d-bdc7-86e3b6eedf65.png)


<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.6/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
