### PR TITLE
Modifica per rendere visibile l'icona it-burger nell'header light.

### DIFF
--- a/src/scss/custom/_headernavbartheme.scss
+++ b/src/scss/custom/_headernavbartheme.scss
@@ -1,10 +1,10 @@
 @media (max-width: #{map-get($grid-breakpoints, lg)}) {
-  .it-header-navbar-wrapper {
-    &.theme-light-desk {
-      .custom-navbar-toggler .icon {
-        fill: $navigation-light-text-color;
-      }
+  .it-header-center-wrapper.theme-light + .it-header-navbar-wrapper {
+    .custom-navbar-toggler .icon {
+      fill: $navigation-light-text-color;
     }
+  }
+  .it-header-navbar-wrapper {
     &.theme-dark-mobile {
       .navbar {
         // navbar mobile


### PR DESCRIPTION
La modifica proposta corregge il bug che non consente la corretta visualizzazione dell'icona it-burger nel menù quando questo è in modalità light.

## Descrizione

Modificata l'assegnazione del colore $navigation-light-text-color che avviene quando l'header centrale ha la classe theme-light. La modifica ricalca quella proposta del rif  [#35](https://github.com/italia/bootstrap-italia-next/issues/35) 

## Checklist

- [ ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.6/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
