### PR TITLE
fix(core): steppers active element on desktop

### DIFF
--- a/src/scss/custom/_steppers.scss
+++ b/src/scss/custom/_steppers.scss
@@ -190,6 +190,7 @@
         }
         // active
         &.active {
+          display: flex;
           &:after {
             content: '';
             position: absolute;
@@ -224,6 +225,7 @@
           border-radius: 50%;
           text-align: center;
           margin-right: 0.667rem;
+          flex-shrink: 0;
           &:after {
             display: none;
           }


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Fix della proprietà display da block ad active della voce attiva dello steppers da breakpoint 992 in su.
Fix dell'ovalizzazione del contenitore del numero step.

Fixes #727 

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
