### PR TITLE
fix(card-img): ripristino padding a destra e sinistra del card-body

### DIFF
--- a/src/scss/custom/_card.scss
+++ b/src/scss/custom/_card.scss
@@ -316,13 +316,6 @@
   }
   // cards with img top
   &.card-img {
-    // Why the margin?
-    // margin-left: $card-padding/3;
-    // margin-right: $card-padding/3;
-    .card-body {
-      padding-left: 0;
-      padding-right: 0;
-    }
     &:after {
       //display: none;
     }


### PR DESCRIPTION
Fixes #737 

Ripristinato il padding a destra e a sinistra di un elemento `card-body` associato ad un elemento `card-img`. Si vedano le immagini allegate alla issue per comprendere l'origine della richiesta.

Se necessario procedo con l'altra soluzione proposta nella issue referenziata.

