### PR TITLE
fix: restored left and right padding to card-body in a card-img

### DIFF
--- a/src/scss/custom/_card.scss
+++ b/src/scss/custom/_card.scss
@@ -316,13 +316,6 @@
   }
   // cards with img top
   &.card-img {
-    // Why the margin?
-    // margin-left: $card-padding/3;
-    // margin-right: $card-padding/3;
-    .card-body {
-      padding-left: 0;
-      padding-right: 0;
-    }
     &:after {
       //display: none;
     }

--- a/src/scss/custom/_card.scss
+++ b/src/scss/custom/_card.scss
@@ -316,6 +316,22 @@
   }
   // cards with img top
   &.card-img {
+    // Why the margin?
+    // margin-left: $card-padding/3;
+    // margin-right: $card-padding/3;
+    .card-body {
+      padding-left: 0;
+      padding-right: 0;
+    }
+
+    &.shadow .card-body,
+    &.border .card-body,
+    &.border-start .card-body,
+    &.border-end .card-body {
+      padding-left: $card-padding;
+      padding-right: $card-padding;
+    }
+
     &:after {
       //display: none;
     }


### PR DESCRIPTION
Fixes #737

Ripristinato il padding a destra e a sinistra di un elemento `card-body` associato ad un elemento `card-img`. Si vedano le immagini allegate alla issue per comprendere l'origine della richiesta.

Se necessario procedo con l'altra soluzione proposta nella issue referenziata.

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
