### PR TITLE
fix: updated z-index value

### DIFF
--- a/src/scss/custom/_sticky.scss
+++ b/src/scss/custom/_sticky.scss
@@ -1,6 +1,6 @@
 .bs-is-sticky {
   position: sticky !important;
-  z-index: 99999 !important;
+  z-index: 9999 !important;
 }
 
 .bs-is-fixed {


### PR DESCRIPTION
Fixes #750

Corretto il valore di `z-index` associato alla classe degli elementi sticky di modo che l'header fixed rimanga sempre in primo piano.
