### PR TITLE
fix: row-column-border on mobile interfaces

### DIFF
--- a/docs/esempi/comuni/template-novita-evento.html
+++ b/docs/esempi/comuni/template-novita-evento.html
@@ -73,10 +73,8 @@ title: Template Evento Comunale
   <div class="container">
     <div class="row row-column-border row-column-menu-left">
       <aside class="col-lg-4">
-        <div class="sticky-wrapper navbar-wrapper">
-          <nav
-            class="navbar it-navscroll-wrapper it-top-navscroll navbar-expand-lg"
-          >
+        <div data-bs-toggle="sticky" data-bs-stackable="true">
+          <nav class="navbar it-navscroll-wrapper it-bottom-navscroll navbar-expand-lg" data-bs-navscroll>
             <button
               class="custom-navbar-toggler"
               type="button"
@@ -84,6 +82,7 @@ title: Template Evento Comunale
               aria-expanded="false"
               aria-label="Toggle navigation"
               data-bs-target="#navbarNav"
+              data-bs-toggle="navbarcollapsible"
             >
               <span class="it-list"></span>Indice della pagina
             </button>

--- a/docs/esempi/comuni/template-novita-evento.html
+++ b/docs/esempi/comuni/template-novita-evento.html
@@ -71,7 +71,7 @@ title: Template Evento Comunale
     </div>
   </div>
   <div class="container">
-    <div class="row border-top row-column-border row-column-menu-left">
+    <div class="row row-column-border row-column-menu-left">
       <aside class="col-lg-4">
         <div class="sticky-wrapper navbar-wrapper">
           <nav

--- a/docs/esempi/comuni/template-novita-notizia.html
+++ b/docs/esempi/comuni/template-novita-notizia.html
@@ -66,7 +66,7 @@ title: Template Pagina Notizia
     </div>
   </div>
   <div class="container">
-    <div class="row border-top row-column-border row-column-menu-left">
+    <div class="row row-column-border row-column-menu-left">
       <aside class="col-lg-4">
         <nav class="navbar it-navscroll-wrapper it-bottom-navscroll navbar-expand-lg" data-bs-navscroll>
           <button

--- a/docs/esempi/comuni/template-servizi-servizio.html
+++ b/docs/esempi/comuni/template-servizi-servizio.html
@@ -52,8 +52,8 @@ title: Template Servizio Comunale
     </div>
     <div class="row row-column-border row-column-menu-left">
       <aside class="col-lg-4">
-        <div class="sticky-wrapper navbar-wrapper">
-          <nav class="navbar it-navscroll-wrapper it-top-navscroll navbar-expand-lg">
+        <div data-bs-toggle="sticky" data-bs-stackable="true">
+          <nav class="navbar it-navscroll-wrapper it-bottom-navscroll navbar-expand-lg" data-bs-navscroll>
             <button
               class="custom-navbar-toggler"
               type="button"
@@ -61,6 +61,7 @@ title: Template Servizio Comunale
               aria-expanded="false"
               aria-label="Toggle navigation"
               data-bs-target="#navbarNav"
+              data-bs-toggle="navbarcollapsible"
             >
               <span class="it-list"></span>Indice della pagina
             </button>

--- a/docs/esempi/comuni/template-servizi-servizio.html
+++ b/docs/esempi/comuni/template-servizi-servizio.html
@@ -50,7 +50,7 @@ title: Template Servizio Comunale
         </div>
       </div>
     </div>
-    <div class="row border-top row-column-border row-column-menu-left">
+    <div class="row row-column-border row-column-menu-left">
       <aside class="col-lg-4">
         <div class="sticky-wrapper navbar-wrapper">
           <nav class="navbar it-navscroll-wrapper it-top-navscroll navbar-expand-lg">

--- a/src/scss/custom/_grid.scss
+++ b/src/scss/custom/_grid.scss
@@ -33,7 +33,6 @@
 
 .row {
   &.row-column-border {
-
     & > [class^='col-'] {
       padding-top: 2rem;
       padding-bottom: 2rem;

--- a/src/scss/custom/_grid.scss
+++ b/src/scss/custom/_grid.scss
@@ -33,7 +33,6 @@
 
 .row {
   &.row-column-border {
-    
 
     & > [class^='col-'] {
       padding-top: 2rem;
@@ -76,7 +75,7 @@
   @include media-breakpoint-up(lg) {
     &.row-column-border {
       margin-top: 1rem;
-	  border-top: 1px solid $border-color;
+      border-top: 1px solid $border-color;
 
       & > [class^='col-'] {
         padding: 3rem 3rem;

--- a/src/scss/custom/_grid.scss
+++ b/src/scss/custom/_grid.scss
@@ -33,7 +33,7 @@
 
 .row {
   &.row-column-border {
-    border-top: 1px solid $border-color;
+    
 
     & > [class^='col-'] {
       padding-top: 2rem;
@@ -76,6 +76,7 @@
   @include media-breakpoint-up(lg) {
     &.row-column-border {
       margin-top: 1rem;
+	  border-top: 1px solid $border-color;
 
       & > [class^='col-'] {
         padding: 3rem 3rem;


### PR DESCRIPTION
Fixes #758

fix: row-column-border, show top border only on large interfaces

## Descrizione

spostata una riga di codice per consentire che il bordo superiore venga mostrato solo nelle interfacce con dimensione superiore a `lg` di modo che nelle interfacce con altre dimensioni vengano visualizzati solo i bordi legati alle colonne figlie della row-column-border.

## Checklist

- [ ] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

