### PR TITLE
fix: gem dependencies for windows environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ gem 'jekyll-redirect-from', '~> 0.16.0'
 gem 'jekyll-sitemap', '~> 1.4.0'
 gem 'jekyll-toc', '~> 0.17.1'
 gem 'html-proofer', '~> 3.19.3'
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+gem 'webrick', '~> 1.7' if Gem.win_platform?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,8 @@ GEM
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     unicode-display_width (1.8.0)
+    wdm (0.1.1)
+    webrick (1.7.0)
     yell (2.2.2)
 
 PLATFORMS
@@ -100,6 +102,8 @@ DEPENDENCIES
   jekyll-redirect-from (~> 0.16.0)
   jekyll-sitemap (~> 1.4.0)
   jekyll-toc (~> 0.17.1)
+  wdm (>= 0.1.0)
+  webrick (~> 1.7)
 
 BUNDLED WITH
    2.3.0


### PR DESCRIPTION
## Descrizione

Nel tentativo di eseguire il comando:
```
npm run documentation-serve
```
sul mio ambiente windows, veniva segnalata la necessità di aggiungere un paio di dipendenze (`wdm` e `webrick`) dentro il `Gemfile`: altrimenti non funzionava.

La modifica va ad aggiungere queste dipendenze, vincolandole al fatto che l'ambiente dove viene eseguito il comando sia di tipo windows. 

## Checklist

Ho verificato la modifica su ambiente windows e tramite WSL 2 su Windows 11.