### PR TITLE
fix: removed duplicate style definitions

### DIFF
--- a/src/scss/custom/_autocomplete.scss
+++ b/src/scss/custom/_autocomplete.scss
@@ -55,7 +55,6 @@
   //single item
   a {
     padding: 12px $v-gap * 3;
-    display: block;
     display: flex;
     justify-content: flex-start;
     align-items: flex-start;


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

È stata rimossa la proprietà `display: block` in quanto già presente `display: flex`

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
