### PR TITLE
[1.x] Remove hardcoded accessible-autocomplete css path

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -131,7 +131,7 @@ gulp.task('scss-min', () => {
     .src(Paths.SOURCE_SCSS)
     .pipe(gap.prependText(bootstrapItaliaBanner))
     .pipe(sourcemaps.init())
-    .pipe(sass().on('error', sass.logError))
+    .pipe(sass({ includePaths: ['node_modules'] }).on('error', sass.logError))
     .pipe(autoprefixer())
     .pipe(
       cleanCSS({

--- a/src/scss/bootstrap-italia.scss
+++ b/src/scss/bootstrap-italia.scss
@@ -152,4 +152,4 @@
 @import 'utilities/icons';
 
 //accessible autocomplete
-@import '../../node_modules/accessible-autocomplete/src/autocomplete.css';
+@import 'accessible-autocomplete/src/autocomplete';


### PR DESCRIPTION
In the main stylesheet at the very last line the accessible-autocomplete CSS is imported using an hardcoded path to the node_modules folder. This PR replaces it with the appropriate source lookup.

## Checklist
- [ ] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.