### PR TITLE
chora: fix divider accessibility

### DIFF
--- a/docs/menu-di-navigazione/toolbar.md
+++ b/docs/menu-di-navigazione/toolbar.md
@@ -178,7 +178,7 @@ Gli elementi disabilitati avranno invece una classe `.disabled` con ulteriori ac
 
 ## Divisori
 
-Per aggiungere degli elementi divisori fra gli elementi utilizzare dei tag `<li>` con classe `.toolbar-divider`, aggiungendo l'attributo `aria-hidden="true"` per nasconderli agli screen reader.
+Per aggiungere degli elementi divisori fra gli elementi utilizzare dei tag `<li>` con classe `.toolbar-divider`, aggiungendo il ruolo separatore `role="separator"` per indicarne la presenza agli screen reader e `aria-orientation="vertical"` per indicarne l'orientamento.
 
 {% capture example %}
 
@@ -196,7 +196,7 @@ Per aggiungere degli elementi divisori fra gli elementi utilizzare dei tag `<li>
         <span class="toolbar-label">immagini</span>
       </a>
     </li>
-    <li class="toolbar-divider" aria-hidden="true"></li>
+    <li class="toolbar-divider" role="separator" aria-orientation="vertical"></li>
     <li>
       <a href="#">
         <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-file"></use></svg>
@@ -209,7 +209,7 @@ Per aggiungere degli elementi divisori fra gli elementi utilizzare dei tag `<li>
         <span class="toolbar-label">privacy</span>
       </a>
     </li>
-    <li class="toolbar-divider" aria-hidden="true"></li>
+    <li class="toolbar-divider" role="separator" aria-orientation="vertical"></li>
     <li>
       <a href="#" class="disabled" disabled aria-disabled="true">
         <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-star-outline"></use></svg>
@@ -756,7 +756,7 @@ Applicando una classe aggiuntiva `.toolbar-vertical` alla Toolbar gli elementi v
         </div>
       </div>
   </li>
-  <li class="toolbar-divider" aria-hidden="true"></li>
+  <li class="toolbar-divider" role="separator" aria-orientation="vertical"></li>
   <li>
       <a href="#">
         <svg class="icon" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-file"></use></svg>
@@ -816,7 +816,7 @@ Applicando una classe aggiuntiva `.toolbar-vertical` alla Toolbar gli elementi v
         </div>
       </div>
     </li>
-    <li class="toolbar-divider" aria-hidden="true"></li>
+    <li class="toolbar-divider" role="separator" aria-orientation="vertical"></li>
     <li>
       <a href="#">
         <span class="visually-hidden">privacy</span>
@@ -876,7 +876,7 @@ Applicando una classe aggiuntiva `.toolbar-vertical` alla Toolbar gli elementi v
         </div>
       </div>
     </li>
-    <li class="toolbar-divider" aria-hidden="true"></li>
+    <li class="toolbar-divider" role="separator" aria-orientation="vertical"></li>
     <li>
         <a href="#">
         <span class="visually-hidden">immagini</span>


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
Rimosso _aria-hidden="true"_ sui listitem del toolbar e aggiunto _role="separator"_ e _aria-orientation="vertical"_, per essere semanticamente allineati tra struttura che vanno a leggere gli screen reader e vista.

issue di riferimento: https://github.com/italia/bootstrap-italia/issues/796

Testato con NVDA 2022.3

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.
