### PR TITLE
[UPD] chiarimenti su documentazione con breaking per select custom

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.9'
 services:
   dev:
+    platform: linux/amd64
     build: .
     volumes:
       - .:/app

--- a/docs/come-iniziare/migrazione-dalla-versione-1.md
+++ b/docs/come-iniziare/migrazione-dalla-versione-1.md
@@ -151,6 +151,7 @@ Tabelle ridisegnate e ricostruite con variabili CSS per un maggior controllo sul
 - <span class="bg-danger text-white px-2">Breaking</span> Le classi di layout specifiche per i form sono state eliminate. Utilizza le griglie e le utilities invece di `.form-row` o `.form-inline`.
 - <span class="bg-danger text-white px-2">Breaking</span> La classe `.form-text` non specifica più il display, permettendo la creazione di testo accessorio di tipo inline o block a seconda della necessità, semplicemente utilizzando `<span>` o `<div>`.
 - <span class="bg-danger text-white px-2">Breaking</span> Se si migra dalla 1.x alla versione 2.2.0 in poi, assicurarsi di aggiungere alla label su input la classe `active` per impedire la sovrapposizione della label al campo stesso nel caso in cui si utilizza l’attributo placeholder o l’input parte già valorizzato.
+- <span class="bg-danger text-white px-2">Breaking</span> Tutti i componenti **select custom** (*reset*, *multipla*, *con gruppi*, *con ricerca*,  *multipla con gruppi e checkboxes*) non sono più supportati dalla versione 2.0.0 e successive
 
 ## Javascript
 

--- a/docs/come-iniziare/migrazione-dalla-versione-1.md
+++ b/docs/come-iniziare/migrazione-dalla-versione-1.md
@@ -151,7 +151,7 @@ Tabelle ridisegnate e ricostruite con variabili CSS per un maggior controllo sul
 - <span class="bg-danger text-white px-2">Breaking</span> Le classi di layout specifiche per i form sono state eliminate. Utilizza le griglie e le utilities invece di `.form-row` o `.form-inline`.
 - <span class="bg-danger text-white px-2">Breaking</span> La classe `.form-text` non specifica più il display, permettendo la creazione di testo accessorio di tipo inline o block a seconda della necessità, semplicemente utilizzando `<span>` o `<div>`.
 - <span class="bg-danger text-white px-2">Breaking</span> Se si migra dalla 1.x alla versione 2.2.0 in poi, assicurarsi di aggiungere alla label su input la classe `active` per impedire la sovrapposizione della label al campo stesso nel caso in cui si utilizza l’attributo placeholder o l’input parte già valorizzato.
-- <span class="bg-danger text-white px-2">Breaking</span> Tutti i componenti **select custom** (*reset*, *multipla*, *con gruppi*, *con ricerca*,  *multipla con gruppi e checkboxes*) non sono più supportati dalla versione 2.0.0 e successive
+- <span class="bg-danger text-white px-2">Breaking</span> Tutti i componenti **Select Custom** (*reset*, *multipla*, *con gruppi*, *con ricerca*,  *multipla con gruppi e checkboxes*) non sono più supportati dalla versione 2.0.0 e successive
 
 ## Javascript
 

--- a/docs/come-iniziare/migrazione-dalla-versione-1.md
+++ b/docs/come-iniziare/migrazione-dalla-versione-1.md
@@ -151,7 +151,7 @@ Tabelle ridisegnate e ricostruite con variabili CSS per un maggior controllo sul
 - <span class="bg-danger text-white px-2">Breaking</span> Le classi di layout specifiche per i form sono state eliminate. Utilizza le griglie e le utilities invece di `.form-row` o `.form-inline`.
 - <span class="bg-danger text-white px-2">Breaking</span> La classe `.form-text` non specifica più il display, permettendo la creazione di testo accessorio di tipo inline o block a seconda della necessità, semplicemente utilizzando `<span>` o `<div>`.
 - <span class="bg-danger text-white px-2">Breaking</span> Se si migra dalla 1.x alla versione 2.2.0 in poi, assicurarsi di aggiungere alla label su input la classe `active` per impedire la sovrapposizione della label al campo stesso nel caso in cui si utilizza l’attributo placeholder o l’input parte già valorizzato.
-- <span class="bg-danger text-white px-2">Breaking</span> Tutti i componenti **Select Custom** (*reset*, *multipla*, *con gruppi*, *con ricerca*,  *multipla con gruppi e checkboxes*) non sono più supportati dalla versione 2.0.0 e successive
+- <span class="bg-danger text-white px-2">Breaking</span> Tutti i componenti **Select Custom** (*reset*, *multipla*, *con gruppi*, *con ricerca*,  *multipla con gruppi e checkboxes*) non sono più supportati dalla versione 2.0.0 e successive.
 
 ## Javascript
 


### PR DESCRIPTION
## Descrizione

Fix issue #830
Aggiornamento per chiarimenti su documentazione con braking per select custom

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

