### PR TITLE
fix: remove display block from active step

### DIFF
--- a/src/scss/custom/_steppers.scss
+++ b/src/scss/custom/_steppers.scss
@@ -64,7 +64,6 @@
             fill: $primary;
           }
         }
-        &.active,
         &.steppers-index {
           display: block;
         }


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Come segnalato da un utente sul canale `#design-system` dello Slack di Developers Italia, dalla versione 2.3.0 di BI è stata introdotta una regressione (#727).

Questa PR prova a risolvere la regressione facendo in modo che non venga applicato `display: block` allo step attivo.
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] <s>La documentazione è stata aggiornata.</s>

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
