### PR TITLE
fix: pager link font weight

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -334,7 +334,7 @@ $pager-item-margin-right: 5px;
 $pager-item-current-color: $primary !default;
 $pager-item-current-border: 1px solid $primary !default;
 $pager-font-size: 0.8888888888888888rem; // 16px
-$pager-font-weight: 600;
+$pager-font-weight: 700;
 $pager-font-color: $secondary !default;
 $pager-hover-color: $primary !default;
 $pager-icon-color: $primary !default;


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

This PR fixes the pager link font-weight, now aligned to the new UI kit v3.0 ([see link](https://www.figma.com/file/2gaQw683ZazAPEILQtFLZF/%5BDesign-system-%E2%80%A8del-Paese%5D---UI-Kit-Italia?type=design&node-id=1486%3A101345&t=6aVsFg5cWJ0vOAWg-1))

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
