### PR TITLE
nav-link anchor set focus on target

### DIFF
--- a/src/js/plugins/navscroll.js
+++ b/src/js/plugins/navscroll.js
@@ -171,6 +171,8 @@ class NavScroll extends BaseComponent {
       } else {
         location.hash = hash
       }
+	  
+	  target.focus()
     }
   }
 

--- a/src/js/plugins/navscroll.js
+++ b/src/js/plugins/navscroll.js
@@ -94,7 +94,6 @@ class NavScroll extends BaseComponent {
 
     SelectorEngine.find(SELECTOR_LINK_CLICKABLE, this._element).forEach((link) => {
       link.addEventListener('click', (event) => {
-        event.preventDefault()
         const scrollHash = () => this._scrollToHash(link.hash)
         if (this._isCollapseOpened) {
           this._callbackQueue.push(scrollHash)
@@ -171,8 +170,6 @@ class NavScroll extends BaseComponent {
       } else {
         location.hash = hash
       }
-
-      target.focus()
     }
   }
 

--- a/src/js/plugins/navscroll.js
+++ b/src/js/plugins/navscroll.js
@@ -244,11 +244,10 @@ class NavScroll extends BaseComponent {
  * ------------------------------------------------------------------------
  */
 
-onDocumentScroll(() => {
-  const navs = SelectorEngine.find(SELECTOR_NAVSCROLL)
-  navs.map((nav) => {
-    NavScroll.getOrCreateInstance(nav)
-  })
+const navs = SelectorEngine.find(SELECTOR_NAVSCROLL)
+navs.map((nav) => {
+  NavScroll.getOrCreateInstance(nav)
 })
+
 
 export default NavScroll

--- a/src/js/plugins/navscroll.js
+++ b/src/js/plugins/navscroll.js
@@ -171,8 +171,8 @@ class NavScroll extends BaseComponent {
       } else {
         location.hash = hash
       }
-	  
-	  target.focus()
+
+      target.focus()
     }
   }
 

--- a/src/js/plugins/navscroll.js
+++ b/src/js/plugins/navscroll.js
@@ -93,7 +93,7 @@ class NavScroll extends BaseComponent {
     }
 
     SelectorEngine.find(SELECTOR_LINK_CLICKABLE, this._element).forEach((link) => {
-      link.addEventListener('click', (event) => {
+      link.addEventListener('click', () => {
         const scrollHash = () => this._scrollToHash(link.hash)
         if (this._isCollapseOpened) {
           this._callbackQueue.push(scrollHash)
@@ -248,6 +248,5 @@ const navs = SelectorEngine.find(SELECTOR_NAVSCROLL)
 navs.map((nav) => {
   NavScroll.getOrCreateInstance(nav)
 })
-
 
 export default NavScroll


### PR DESCRIPTION

## Descrizione

Fixes #944

ho rimosso anche il fatto che gli effetti di scroll, e tutto il resto ad essi collegati, si attivassero solo dopo che l'utente effettuasse uno scroll della pagina in quanto la cosa crea dei comportamenti inattesi in modalità mobile (se si usa il menu laterale sticky bottom) e non abilita le animazioni.

## Checklist

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
