### PR TITLE
Fix typos nella documentazione

### DIFF
--- a/docs/come-iniziare/componente-base.md
+++ b/docs/come-iniziare/componente-base.md
@@ -26,7 +26,7 @@ Il file `src/scss/custom/_componente-base.scss` permette al componente di avere 
 
 ### Comportamento dinamico
 
-Il file `src/js/plugins/componente-base.js` abilita all'evento `click` un tracciamento del valore presente nell'attributo `data-value`. Per visualizzare il risultato aprire la `console` tra gli strumenti per sviluppatori presenti in tutti i browser. Questo file Javascript utilizza una stuttura dettata da una convenzione per la creazione di plugin di Bootstrap {{ site.bootstrap_version }}, che permette di avere più flessibilità nella gestione degli eventi ed esporre le Data-API per l'estensione del loro utilizzo e di esporre proprietà del componente stesso:
+Il file `src/js/plugins/componente-base.js` abilita all'evento `click` un tracciamento del valore presente nell'attributo `data-value`. Per visualizzare il risultato aprire la `console` tra gli strumenti per sviluppatori presenti in tutti i browser. Questo file Javascript utilizza una struttura dettata da una convenzione per la creazione di plugin di Bootstrap {{ site.bootstrap_version }}, che permette di avere più flessibilità nella gestione degli eventi ed esporre le Data-API per l'estensione del loro utilizzo e di esporre proprietà del componente stesso:
 
 ```js
 $.fn.componenteBase.Constructor.VERSION

--- a/docs/come-iniziare/introduzione.md
+++ b/docs/come-iniziare/introduzione.md
@@ -85,7 +85,7 @@ Per la versione non bundle, dopo aver copiato i file all'interno del progetto, s
 
 #### Moduli
 
-In alternativa se si vogliono utilizzare i moduli,  è possibile importare e utilizzare singolarmente i vari componenti. Di seguito un esempio di cui potete trovare l'intero esempio completo [qui](https://github.com/astagi/demo-bsitalia-2).
+In alternativa se si vogliono utilizzare i moduli, è possibile importare e utilizzare singolarmente i vari componenti. Di seguito un esempio di cui potete trovare l'intero esempio completo [qui](https://github.com/astagi/demo-bsitalia-2).
 
 ```js
 import { CarouselBI, Alert, Notification, Tooltip, Sticky, loadFonts } from 'bootstrap-italia'

--- a/docs/come-iniziare/migrazione-dalla-versione-1.md
+++ b/docs/come-iniziare/migrazione-dalla-versione-1.md
@@ -63,7 +63,7 @@ La compilazione del progetto è stata migrata da gulp.js a [rollup.js](https://r
   - <span class="bg-danger text-white px-2">Breaking</span> Rinominata la classe `.no-gutters` a `.g-0` per allinearla alle altre classi dei gutter.
 - Alle colonne non è più applicata la proprietà `position: relative`, potrebbe essere necessario applicare la classe `.position-relative` ad alcuni elementi per ristabilire il comportamento originale.
 - <span class="bg-danger text-white px-2">Breaking</span> Eliminate diverse classi `.order-*`, solitamente poco utilizzate. Ora vengono fornite solo le classi da `.order-1` a `.order-5`.
-- <span class="bg-danger text-white px-2">Breaking</span> `bootstrap-grid.css` ora applica `box-sizing: border-box` solo alla colonna invece di resettare il box-sizing globale. Questo per permettere l'utilizzo dei nostri stili di di griglia in più contesti senza creare interferenze.
+- <span class="bg-danger text-white px-2">Breaking</span> `bootstrap-grid.css` ora applica `box-sizing: border-box` solo alla colonna invece di resettare il box-sizing globale. Questo per permettere l'utilizzo dei nostri stili di griglia in più contesti senza creare interferenze.
 
 ### Proporzioni
 

--- a/docs/come-iniziare/migrazione-dalla-versione-1.md
+++ b/docs/come-iniziare/migrazione-dalla-versione-1.md
@@ -151,7 +151,7 @@ Tabelle ridisegnate e ricostruite con variabili CSS per un maggior controllo sul
 - <span class="bg-danger text-white px-2">Breaking</span> Le classi di layout specifiche per i form sono state eliminate. Utilizza le griglie e le utilities invece di `.form-row` o `.form-inline`.
 - <span class="bg-danger text-white px-2">Breaking</span> La classe `.form-text` non specifica più il display, permettendo la creazione di testo accessorio di tipo inline o block a seconda della necessità, semplicemente utilizzando `<span>` o `<div>`.
 - <span class="bg-danger text-white px-2">Breaking</span> Se si migra dalla 1.x alla versione 2.2.0 in poi, assicurarsi di aggiungere alla label su input la classe `active` per impedire la sovrapposizione della label al campo stesso nel caso in cui si utilizza l’attributo placeholder o l’input parte già valorizzato.
-- <span class="bg-danger text-white px-2">Breaking</span> Tutti i componenti **Select Custom** (*reset*, *multipla*, *con gruppi*, *con ricerca*,  *multipla con gruppi e checkboxes*) non sono più supportati dalla versione 2.0.0 e successive.
+- <span class="bg-danger text-white px-2">Breaking</span> Tutti i componenti **Select Custom** (*reset*, *multipla*, *con gruppi*, *con ricerca*, *multipla con gruppi e checkboxes*) non sono più supportati dalla versione 2.0.0 e successive.
 
 ## Javascript
 

--- a/docs/come-iniziare/personalizzazione-della-libreria.md
+++ b/docs/come-iniziare/personalizzazione-della-libreria.md
@@ -82,4 +82,4 @@ function App() {
 export default App
 ```
 
-In questo semplice e veloce esempio, il pulsante con classe **.btn-primary** avrà lo sfondo di colore **rosso** anzichè il default blu.
+In questo semplice e veloce esempio, il pulsante con classe **.btn-primary** avrà lo sfondo di colore **rosso** anziché il default blu.

--- a/docs/come-iniziare/personalizzazione-della-libreria.md
+++ b/docs/come-iniziare/personalizzazione-della-libreria.md
@@ -6,7 +6,7 @@ group: come-iniziare
 toc: true
 ---
 
-**Bootstrap Italia** eredita ed estende tutte le variabili di default di Bootstrap, sovrascrivendo alcuni valori in fase di compilazione e impostandone di nuovi all'occorenza.
+**Bootstrap Italia** eredita ed estende tutte le variabili di default di Bootstrap, sovrascrivendo alcuni valori in fase di compilazione e impostandone di nuovi all'occorrenza.
 Un esempio fra tutti è il valore del colore `$primary` che in **Bootstrap Italia** è rappresentato dal colore blu `#0066CC`, tipico della libreria.
 
 L'utilizzo del blu `#0066CC` dovrebbe però essere riservato alle amministrazioni centrali dello Stato, e quindi ci si può trovare nella condizione di dover personalizzare i valori delle variabili colore di **Bootstrap Italia**, impostando nuovi valori per le proprie necessità.

--- a/docs/componenti/affix.md
+++ b/docs/componenti/affix.md
@@ -102,7 +102,7 @@ Un elemento Affix a sviluppo orizzontale può essere ancorato alla parte alta o 
 
 ### Horizontal Affix top
 
-Per ancorare un elemento a svliuppo orizzontale alla parte alta della pagina è sufficiente applicare la classe `.affix-parent` all'elemento che lo contiene e la classe `.affix-top` all'elemento stesso.
+Per ancorare un elemento a sviluppo orizzontale alla parte alta della pagina è sufficiente applicare la classe `.affix-parent` all'elemento che lo contiene e la classe `.affix-top` all'elemento stesso.
 
 {% comment %}Example name: Orizzontale in alto{% endcomment %}
 {% capture example %}

--- a/docs/componenti/buttons.md
+++ b/docs/componenti/buttons.md
@@ -224,7 +224,7 @@ Per creare pulsanti o gruppi di pulsanti a tutta larghezza, come i _block button
 </div>
 {% endcapture %}{% include example.html content=example %}
 
-In questo caso è stata implemenentata una variante responsive che visualizza i tasti a tutta larghezza e sovrapposti in mobile per poi affiancarli dl breakpoint `md` in su.
+In questo caso è stata implementata una variante responsive che visualizza i tasti a tutta larghezza e sovrapposti in mobile per poi affiancarli dl breakpoint `md` in su.
 
 {% comment %}Example name: A tutta larghezza, solo su mobile{% endcomment %}
 {% capture example %}

--- a/docs/componenti/callout.md
+++ b/docs/componenti/callout.md
@@ -179,7 +179,7 @@ Per aumentare la dimensione di un paragrafo contenuto nel Callout applicare la c
 
 ### Highlight Danger
 
-{% comment %}Example name: Periocolo o errore, in evidenza{% endcomment %}
+{% comment %}Example name: Pericolo o errore, in evidenza{% endcomment %}
 {% capture example %}
 
 <div class="callout callout-highlight danger">

--- a/docs/componenti/card.md
+++ b/docs/componenti/card.md
@@ -164,7 +164,7 @@ Per inserire la categorizzazione con relativa icona, usare l'elemento `.category
 </div>
 {% endcapture %}{% include example.html content=example %}
 
-Un'altro esempio di card contenente intestazione (in questo caso numero di files
+Un altro esempio di card contenente intestazione (in questo caso numero di files
 presenti) e icona: la struttura è uguale alla card precedente, per l'intestazione
 è sufficiente usare l'elemento `.categoryicon-top` ed inserire al suo interno gli
 elementi come da esempio.

--- a/docs/componenti/dropdown.md
+++ b/docs/componenti/dropdown.md
@@ -244,7 +244,7 @@ Aggiungere la classe `.disabled` ai link del dropdown che si vogliono mostrare c
 
 All'interno del menu dropdown possono essere inseriti header e separatori.
 
-{% comment %}Example name: Menu con instestazioni e separatori{% endcomment %}
+{% comment %}Example name: Menu con intestazioni e separatori{% endcomment %}
 {% capture example %}
 
 <div class="dropdown-menu">

--- a/docs/componenti/forward.md
+++ b/docs/componenti/forward.md
@@ -8,7 +8,7 @@ description: Consente all'utente di far scorrere automaticamente a una parte spe
 
 ## Esempio
 
-Per attivare lo scorrimento automatico del documento all'àncora indicata nell'attibuto `href` o dall'attributo `data-bs-target`, è sufficiente aggiungere al tag link l'attributo `data-bs-toggle="forward"` e la classe `.forward`:
+Per attivare lo scorrimento automatico del documento all'àncora indicata nell'attributo `href` o dall'attributo `data-bs-target`, è sufficiente aggiungere al tag link l'attributo `data-bs-toggle="forward"` e la classe `.forward`:
 
 {% comment %}Example name: Base{% endcomment %}
 {% capture example %}

--- a/docs/componenti/hero.md
+++ b/docs/componenti/hero.md
@@ -21,7 +21,7 @@ Il componente Hero può contenere:
 
 #### Accessibilità
 
-Valutare attentantamente l'opportunità di utilizzare più hero nella stessa pagina.
+Valutare attentamente l'opportunità di utilizzare più hero nella stessa pagina.
 
 {% endcapture %}{% include callout.html content=callout type="accessibility" %}
 

--- a/docs/componenti/introduzione.md
+++ b/docs/componenti/introduzione.md
@@ -8,7 +8,7 @@ redirect_from:
   - '/docs/componenti/'
 ---
 
-Bootstrap Italia fornisce un'estesa libreria di componenti con cui contruire un sito web.
+Bootstrap Italia fornisce un'estesa libreria di componenti con cui costruire un sito web.
 
 Alcuni di essi sono presenti nella libreria Bootstrap {{ site.bootstrap_version }}, e di conseguenza avranno una corrispondente voce in inglese anche nella [documentazione][documentazione-bootstrap] di Bootstrap stesso. Tali componenti sono personalizzati nello stile, nell'accessibilità e nelle funzionalità per rispondere alle [Linee guida di design per i siti internet e i servizi digitali della PA][linee-guida].
 

--- a/docs/componenti/modale.md
+++ b/docs/componenti/modale.md
@@ -603,7 +603,7 @@ Le modali hanno due dimensioni opzionali, disponibili tramite classi da posizion
 {% comment %}Example name: Varianti di dimensione{% endcomment %}
 {% capture example %}
 <!-- Small modal -->
-<button type="button" class="btn btn-primary " data-bs-toggle="modal" data-bs-target=".bd-example-modal-sm">Modale piccola</button>
+<button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target=".bd-example-modal-sm">Modale piccola</button>
 
 <div class="modal fade bd-example-modal-sm" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-sm">

--- a/docs/componenti/modale.md
+++ b/docs/componenti/modale.md
@@ -40,7 +40,7 @@ Prima di utilizzare il componente modale di Bootstrap, assicurati di leggere qua
 
 - Le modali sono costruite in HTML, CSS, e JavaScript. Sono posizionate al di sopra di ogni altro elemento della pagina
   e rimuovono lo scroll dal `<body>` in modo che il contenuto della modale invece scorra.
-- Cliccando sulla parte che oscura la pagina (il cosiddetto _backdrop_ della modale), questa verrà chiusa automativamente.
+- Cliccando sulla parte che oscura la pagina (il cosiddetto _backdrop_ della modale), questa verrà chiusa automaticamente.
 - A causa di come HTML5 definisce la sua semantica, [l'attributo HTML `autofocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autofocus)
   non ha effetto sulle modali di Bootstrap. Per ottenere lo stesso effetto, usa un codice JavaScript personalizzato:
 

--- a/docs/componenti/modale.md
+++ b/docs/componenti/modale.md
@@ -91,7 +91,7 @@ Per chiudere la modale, si può utilizzare un pulsante con classe `.btn-close`.
 
 {% capture callout %}
 
-#### Accessibilità pulsante di chiusra
+#### Accessibilità pulsante di chiusura
 
 **Assicurati di inserire del testo per gli screen readers**, utilizzando l'attributo `aria-label`.
 {% endcapture %}{% include callout.html content=callout type="accessibility" %}

--- a/docs/componenti/notifiche.md
+++ b/docs/componenti/notifiche.md
@@ -56,7 +56,7 @@ Per ragioni di accessibilità è necessario:
 
 ## Esempio
 
-La notifica può essere composta da un solo titolo oppure da un titolo accompagnato da icona, contentuta nel tag `<h5>` del titolo. In questo caso l'elemento dovrà avere la classe `.with-icon`.
+La notifica può essere composta da un solo titolo oppure da un titolo accompagnato da icona, contenuta nel tag `<h5>` del titolo. In questo caso l'elemento dovrà avere la classe `.with-icon`.
 
 {% comment %}Example name: Base, con o senza icona{% endcomment %}
 {% capture example %}
@@ -184,7 +184,7 @@ Alle notifiche possono essere applicate classi aggiuntive che ne determinano lo 
 
 ## Posizione e arrotondamento degli angoli
 
-La posizione predefinita della notifiche è nella parte destra inferiore della finestra.
+La posizione predefinita delle notifiche è nella parte destra inferiore della finestra.
 
 Utilizzando le classi aggiuntive di posizione fissa elencate di seguito la notifica verrà posizionata a filo di uno dei margini indicati, modificando l'arrotondamento degli angoli di conseguenza.
 

--- a/docs/componenti/paginazione.md
+++ b/docs/componenti/paginazione.md
@@ -42,7 +42,7 @@ Poiché è molto probabile che la pagina possa contenere più di un elemento `<n
 
 ## Stato disabilitato e attivo
 
-I link della paginazione assumonono uno stato disabilitato usando la classe `.disabled` nel tag `<li>`.
+I link della paginazione assumono uno stato disabilitato usando la classe `.disabled` nel tag `<li>`.
 Per indicare la pagina attiva corrente utilizzare l'attributo `aria-current="page"` nel tag `<a>`, l'aspetto grafico cambierà di conseguenza.
 
 {% capture callout %}
@@ -397,7 +397,7 @@ Notare come sia stato inserito il testo "Pagina" in un elemento `<span class="vi
 
 ### Total number
 
-Aggiungendo al classe `.pagination-total` al tag `<nav>` che contiene la paginazione è possibile indicare il numero totale di elementi o il numero totale di elementi per pagina all'interno di un tag `<p>` collocato priam della chiusura del `<nav>`.
+Aggiungendo la classe `.pagination-total` al tag `<nav>` che contiene la paginazione è possibile indicare il numero totale di elementi o il numero totale di elementi per pagina all'interno di un tag `<p>` collocato priam della chiusura del `<nav>`.
 
 {% comment %}Example name: Con numero totale elementi{% endcomment %}
 {% capture example %}

--- a/docs/componenti/popover.md
+++ b/docs/componenti/popover.md
@@ -183,7 +183,7 @@ Inizializza i popover per una raccolta di elementi.
 
 #### `show`
 
-Mostra il popover di un elemento. **Ritorna al chiamante prima che il popover sia stato effettivamente mostrato** (prima che si verifichi l'evento `shown.bs.popover`). Questo è considerato un'attivazione "manuale" del popover. I popover senza nè titoli nècontenuto non vengono mai visualizzati.
+Mostra il popover di un elemento. **Ritorna al chiamante prima che il popover sia stato effettivamente mostrato** (prima che si verifichi l'evento `shown.bs.popover`). Questo è considerato un'attivazione "manuale" del popover. I popover senza nè titoli nè contenuto non vengono mai visualizzati.
 
 ```js
 myPopover.show()
@@ -287,7 +287,7 @@ var popover = bootstrap.Popover.getOrCreateInstance(exampleTriggerEl) // Returns
     </tr>
     <tr>
       <td>hidden.bs.popover</td>
-      <td>Questo evento viene generato quando il popover ha finito di essere nascosto all'utente (attenderà il completamento delle transizioni CSS)..</td>
+      <td>Questo evento viene generato quando il popover ha finito di essere nascosto all'utente (attenderà il completamento delle transizioni CSS).</td>
     </tr>
     <tr>
       <td>inserted.bs.popover</td>

--- a/docs/componenti/progress-indicators.md
+++ b/docs/componenti/progress-indicators.md
@@ -178,7 +178,7 @@ Non dimenticare il testo esplicativo dedicato agli Screen Reader all'interno di 
 
 Quando non è possibile stabilire una percentuale di progressione utilizzare una Progress Bar di tipo indeterminato, aggiungendo una classe `.progress-indeterminate` al contenitore `.progress` ed eliminando gli attributi `aria-` dalla Progress Bar.
 
-{% comment %}Example name: Progresso intederminato{% endcomment %}
+{% comment %}Example name: Progresso indeterminato{% endcomment %}
 {% capture example %}
 <div class="progress progress-indeterminate">
   <span class="visually-hidden">In elaborazione...</span>

--- a/docs/componenti/sections.md
+++ b/docs/componenti/sections.md
@@ -48,7 +48,7 @@ Gli autori dovrebbero dividere la pagina in sezioni semantiche reali e non per s
 
 ## Colori di sfondo
 
-Il componente Section ha, per default, uno sfondo trasparente. Aggiungendo le classi sottoelencate è possbile aggiungere colori di sfondo.
+Il componente Section ha, per default, uno sfondo trasparente. Aggiungendo le classi sottoelencate è possibile aggiungere colori di sfondo.
 
 ### Sfondo Tenue
 

--- a/docs/componenti/tab.md
+++ b/docs/componenti/tab.md
@@ -612,7 +612,7 @@ Le label dei Tab possono essere sostituite da icone, avendo cura di includere al
 
 ## Posizione dei Tab
 
-Per questioni di accessibilità è preferibile utilizzare le proprietà Flex di CSS a un cambio di posizione dei Tab nell'HTML. Per garantiore un flusso di lettura naturale della pagina i tab di navigazione devono precedere il contenuto a loro associato.
+Per questioni di accessibilità è preferibile utilizzare le proprietà Flex di CSS a un cambio di posizione dei Tab nell'HTML. Per garantire un flusso di lettura naturale della pagina i tab di navigazione devono precedere il contenuto a loro associato.
 
 ### Orizzontale in fondo
 

--- a/docs/componenti/tooltip.md
+++ b/docs/componenti/tooltip.md
@@ -10,7 +10,7 @@ I tooltip sono suggerimenti personalizzati con CSS e JavaScript, utilizzano CSS3
 
 {% capture callout %}
 
-#### Accessibiltà
+#### Accessibilità
 
 I tooltip funzionano sia con la tastiera che per gli utenti dotati di tecnologia assistiva.
 

--- a/docs/componenti/video-player.md
+++ b/docs/componenti/video-player.md
@@ -368,7 +368,7 @@ Video.js importandolo come script.
 
 {% capture callout %}
 
-Coinvolgi il Responsabile per la protezione dei dati (RDP/DPO) della tua amministrazione e ricordati di aggiornare la cookie policy del sito. Designers Italia mette a disposizione il [kit Privacy](https://designers.italia.it/risorse-per-progettare/organizzare/privacy/)  per approfondire questi temi e in particolare uno strumento dedicato alla redazione della Cookie policy che trovi in [questa azione del kit](https://designers.italia.it/risorse-per-progettare/organizzare/privacy/rispetta-la-privacy-per-il-go-live-di-un-sito/).
+Coinvolgi il Responsabile per la protezione dei dati (RDP/DPO) della tua amministrazione e ricordati di aggiornare la cookie policy del sito. Designers Italia mette a disposizione il [kit Privacy](https://designers.italia.it/risorse-per-progettare/organizzare/privacy/) per approfondire questi temi e in particolare uno strumento dedicato alla redazione della Cookie policy che trovi in [questa azione del kit](https://designers.italia.it/risorse-per-progettare/organizzare/privacy/rispetta-la-privacy-per-il-go-live-di-un-sito/).
 
 {% endcapture %}{% include callout.html content=callout type="info" %}
 

--- a/docs/componenti/video-player.md
+++ b/docs/componenti/video-player.md
@@ -15,7 +15,7 @@ la personalizzazione dell'interfaccia utente e l'integrazione con API esterne.
 
 #### Accessibilità
 
-Le persone che utilizzano le tecnologie assistive possono agevolmente accedere ai comandi di questo player video, tuttavia per rendere accessibile un contenuto video è necessario soddisfare i Criteri di Successo contenuti nella [linee guida 1.2 Media temporizzati delle WCAG (versione corrente)](https://www.w3.org/Translations/WCAG21-it/#time-based-media). In particolare:
+Le persone che utilizzano le tecnologie assistive possono agevolmente accedere ai comandi di questo player video, tuttavia per rendere accessibile un contenuto video è necessario soddisfare i Criteri di Successo contenuti nelle [linee guida 1.2 Media temporizzati delle WCAG (versione corrente)](https://www.w3.org/Translations/WCAG21-it/#time-based-media). In particolare:
  - Se il contenuto è costituito da “solo video” oppure “solo audio”, è necessario fornire una trascrizione (Criterio di Successo 1.2.1)
  - Fornire sempre sottotitoli (Criterio di Successo 1.2.2).
  - Fornire audio descrizioni quando sono presenti scene o contenuti non descritte dalla traccia audio primaria. (Criteri di Successo 1.2.3 e 1.2.5)

--- a/docs/form/checkbox.md
+++ b/docs/form/checkbox.md
@@ -41,7 +41,7 @@ Per allineare orizzontalmente le `checkbox` basterà aggiungere la classe `.form
 
 ### Disabilitato
 
-Affinchè i campi `checkbox` e `radio` risultino disabilitati occorrerà aggiungere l'attributo `disabled` all'input e la classe `.disabled` alla label relativa.
+Affinché i campi `checkbox` e `radio` risultino disabilitati occorrerà aggiungere l'attributo `disabled` all'input e la classe `.disabled` alla label relativa.
 
 {% comment %}Example name: Disabilitato {% endcomment %}
 {% capture example %}

--- a/docs/form/input.md
+++ b/docs/form/input.md
@@ -160,7 +160,7 @@ Per rendere più semplice l'inserimento della password, l'elemento è stato dota
   </tbody>
 </table>
 
-E' possibile personalizzare i testi dei messaggi riguardanti la robustezza della password usando gli attributi data dell'elemento `small.form-text`.
+È possibile personalizzare i testi dei messaggi riguardanti la robustezza della password usando gli attributi data dell'elemento `small.form-text`.
 
 <table class="table table-bordered table-striped">
   <thead>

--- a/docs/form/input.md
+++ b/docs/form/input.md
@@ -17,7 +17,7 @@ description: Elementi e stili per la creazione di input accessibili e responsivi
 
 ## Esempi di campi di input
 
-Per il corretto funzionamento degli elementi di tipo `<input>` è di fondamentale importanza l'utilizzo uno degli appositi attributi `type` (ad esempio, `email` per l'inserimento di indirizzi email o `number` per informazioni numeriche), in modo da sfruttare i controlli nativi dei borowser più recenti come la verifica dell'email, l'utilizzo di metodo di input numerico ed altro.
+Per il corretto funzionamento degli elementi di tipo `<input>` è di fondamentale importanza l'utilizzo uno degli appositi attributi `type` (ad esempio, `email` per l'inserimento di indirizzi email o `number` per informazioni numeriche), in modo da sfruttare i controlli nativi dei browser più recenti come la verifica dell'email, l'utilizzo di metodo di input numerico ed altro.
 
 Per l'inserimento guidato di campi di tipo numerico si può anche utilizzare l'elemento dedicato che fornisce migliorie per la validazione e per l'esperienza complessiva, descritto alla [pagina dedicata all'input numerico]({{ site.baseurl }}/docs/form/input-numerico/).
 
@@ -82,7 +82,7 @@ In caso di necessità, è anche possibile utilizzare un ulteriore contenuto test
 
 #### Associazione del testo di aiuto con gli elementi del modulo form
 
-Il testo di aiuto deve essere esplicitamente associato agli elementi del mudulo form a cui si riferisce utilizzando l'attributo `aria-describedby`. Ciò garantirà che le tecnologie assistive, come gli screenreader, leggano questo testo di aiuto quando l'utente avrà il focus sull'elemento.
+Il testo di aiuto deve essere esplicitamente associato agli elementi del modulo form a cui si riferisce utilizzando l'attributo `aria-describedby`. Ciò garantirà che le tecnologie assistive, come gli screenreader, leggano questo testo di aiuto quando l'utente avrà il focus sull'elemento.
 
 {% endcapture %}{% include callout.html content=callout type="accessibility" %}
 

--- a/docs/form/radio-button.md
+++ b/docs/form/radio-button.md
@@ -43,7 +43,7 @@ Per allineare orizzontalmente le `checkbox` o i `radio` basterà aggiungere la c
 
 ### Disabilitato
 
-Affinchè i campi `checkbox` e `radio` risultino disabilitati occorrerà aggiungere l'attributo `disabled` all'input e la classe `.disabled` alla label relativa.
+Affinché i campi `checkbox` e `radio` risultino disabilitati occorrerà aggiungere l'attributo `disabled` all'input e la classe `.disabled` alla label relativa.
 
 {% comment %}Example name: Disabilitato {% endcomment %}
 {% capture example %}

--- a/docs/form/toggles.md
+++ b/docs/form/toggles.md
@@ -37,7 +37,7 @@ Per ottenere un interruttore con levetta basterà usare la seguente sintassi HTM
 
 ### Disabilitato
 
-Affinchè l'interruttore risulti disabilitato occorrerà aggiungere l'attributo `disabled` al checkbox.
+Affinché l'interruttore risulti disabilitato occorrerà aggiungere l'attributo `disabled` al checkbox.
 
 {% comment %}Example name: Disabilitato {% endcomment %}
 {% capture example %}

--- a/docs/form/upload.md
+++ b/docs/form/upload.md
@@ -285,7 +285,7 @@ In questo caso è l'interno form ad avere una classe specifica `upload-dragdrop`
 
 I primi due stati sono gestiti dal codice JS incluso nello UI-Kit, lo stato di **success** dipende dal caricamento corretto del file sul server e va quindi gestito da chi svilupperà il font/back-end del sito o webapp.
 
-Su questa pagina è presente <a href="#esempio-animato">un'esempio simulato</a> del risultato finale.
+Su questa pagina è presente <a href="#esempio-animato">un esempio simulato</a> del risultato finale.
 
 Lo stato dell'upload è rappresentato graficamente dall'elemento `<div class="progress-donut" data-bs-progress-donut></div>` come progress circolare.
 

--- a/docs/menu-di-navigazione/bottomnav.md
+++ b/docs/menu-di-navigazione/bottomnav.md
@@ -31,7 +31,7 @@ Il componente, di altezza fissa, è ancorato al fondo della pagina e ne occupa t
 
 Ogni link `<a>` contiene un icona con classe `.icon` e una label contenuta in uno `<span>` con classe `.bottom-nav-label`.
 
-Il link `<a>` attivo possiede una una classe `.active`.
+Il link `<a>` attivo possiede una classe `.active`.
 
 {% comment %}Example name: Base{% endcomment %}
 {% capture example %}

--- a/docs/menu-di-navigazione/breadcrumbs.md
+++ b/docs/menu-di-navigazione/breadcrumbs.md
@@ -16,7 +16,7 @@ Nelle breadcrumbs c'è la possibilità di scegliere il carattere da usare come s
 
 Dato che le breadcrumb sono uno strumento di navigazione del sito, è buona idea aggiungere un'etichetta significativa come `aria-label="Percorso di navigazione"` per descrivere il tipo di navigazione fornito nell'elemento `<nav>`, nonché applicare `aria-current="page"` all'ultimo elemento del set per indicare che rappresenta la pagina corrente.
 
-Per maggiorni informazioni, guarda le [linee guida WAI-ARIA per la creazione di breadcrumb](https://www.w3.org/TR/wai-aria-practices/#breadcrumb).
+Per maggiori informazioni, guarda le [linee guida WAI-ARIA per la creazione di breadcrumb](https://www.w3.org/TR/wai-aria-practices/#breadcrumb).
 
 {% endcapture %}{% include callout.html content=callout type="accessibility" %}
 

--- a/docs/menu-di-navigazione/header.md
+++ b/docs/menu-di-navigazione/header.md
@@ -1354,7 +1354,7 @@ Affinché la testata rimanga visibile in formato ridotto anche allo scorrere del
 
 ### Tramite JavaScript
 
-E' possibile inizializzare il componente tramite JavaScript:
+È possibile inizializzare il componente tramite JavaScript:
 
 ```js
 var headerSticky = new bootstrap.HeaderSticky(document.getElementById('myHeaderSticky'), options)

--- a/docs/menu-di-navigazione/header.md
+++ b/docs/menu-di-navigazione/header.md
@@ -27,7 +27,7 @@ L'header di un sito della Pubblica Amministrazione è solitamente composto di 3 
 
 #### Accessibilità
 
-Condierando l'importanza dell'Header per la navigazione di un sito, si consiglia di seguire attentamente gli esempi per quanto riguarda l'utilizzo di attributi `ARIA` e labelling accessibile.
+Considerando l'importanza dell'Header per la navigazione di un sito, si consiglia di seguire attentamente gli esempi per quanto riguarda l'utilizzo di attributi `ARIA` e labelling accessibile.
 
 Il titolo del sito, "Nome dell'Istituzione" negli esempi, è contenuto in un `<div>` generico e non un tag `<h1>` per evitare conflitti con gli `<h1>` presenti nelle singole pagine. Nel caso in cui la home page fosse priva di un titolo relativo all'Istituzione (es: carousel con ultime notizie) è consigliabile applicare il tag `<h1>` al titolo dell'header unicamente in quella pagina.
 

--- a/docs/menu-di-navigazione/megamenu.md
+++ b/docs/menu-di-navigazione/megamenu.md
@@ -631,7 +631,7 @@ All'interno dell'ultimo tag `<div class="col-xs-12 col-lg-4">` inseriremo il tag
 Possiamo inserire a destra del megamenu un'immagine ed una descrizione riguardante la sezione.
 
 All'interno dell'ultimo tag `<div class="col-xs-12 col-lg-4">` inseriremo il tag `<div class="row max-height-col">` che a sua volta conterrà la colonna `<div class="col-12 it-vertical it-description">` all'interno della quale andremo ad inserire il blocco contenente immagine e testo.  
-Il tag contenente immagine e descrizione sarà : `<div class="description-content">`.
+Il tag contenente immagine e descrizione sarà: `<div class="description-content">`.
 
 {% comment %}Example name: Con immagine e descrizione{% endcomment %}
 {% capture example %}

--- a/docs/menu-di-navigazione/megamenu.md
+++ b/docs/menu-di-navigazione/megamenu.md
@@ -10,7 +10,7 @@ toc: true
 
 Il megamenu, all'interno del `<nav>`, è una variazione del componente [dropdown]({{ site.baseurl }}/docs/componenti/dropdown/) contenente un elenco di links.
 
-Per stilare correttamente il megamenu è sufficiente aggiungere la classe `.has-megamenu` al tag `<nav class="navbar">`. Ai dropdown dei quali si desidera modificare l'aspetto transformandoli in megamenu è sufficiente aggiungere la classe `.has-megamenu` al tag `<li class="nav-item dropdown">`.
+Per stilare correttamente il megamenu è sufficiente aggiungere la classe `.has-megamenu` al tag `<nav class="navbar">`. Ai dropdown dei quali si desidera modificare l'aspetto trasformandoli in megamenu è sufficiente aggiungere la classe `.has-megamenu` al tag `<li class="nav-item dropdown">`.
 
 Gli elementi megamenu contenuti nelle navbar sono gestiti come elementi di tipo **collapse** nella loro versione mobile.
 

--- a/docs/menu-di-navigazione/torna-su.md
+++ b/docs/menu-di-navigazione/torna-su.md
@@ -72,7 +72,7 @@ Aggiungendo la classe `.shadow` al link si aggiunge un'ombra al pulsante.
 
 ### Versione per sfondo scuro
 
-Aggiungendo la classe `.dark` al link si ottiente un pulsante utilizzabile su sfondo scuro.
+Aggiungendo la classe `.dark` al link si ottiene un pulsante utilizzabile su sfondo scuro.
 
 {% comment %}Example name: Per sfondo scuro, esempio{% endcomment %}
 {% capture example %}
@@ -88,7 +88,7 @@ Aggiungendo la classe `.dark` al link si ottiente un pulsante utilizzabile su sf
 
 #### Ombra su sfondo scuro
 
-Aggiungendo le classi `.dark` e `.shadow` al link si ottiente un pulsante con ombra utilizzabile su sfondo scuro.
+Aggiungendo le classi `.dark` e `.shadow` al link si ottiene un pulsante con ombra utilizzabile su sfondo scuro.
 
 {% comment %}Example name: Con ombra, per sfondo scuro, esempio{% endcomment %}
 {% capture example %}

--- a/docs/organizzare-gli-spazi/griglie.md
+++ b/docs/organizzare-gli-spazi/griglie.md
@@ -46,7 +46,7 @@ Analizzandolo nel dettaglio, ecco come funziona:
 - Le righe sono involucri per colonne. Ogni colonna ha un spaziature orizzontale (`gutter`) per regolare lo spazio tra di esse. Questo `padding` viene poi neutralizzato dalle righe con margini negativi. In questo modo, tutto il contenuto nelle colonne viene allineato sul lato sinistro.
 - In un layout a griglia, il contenuto deve essere posizionato all'interno di colonne e solo le colonne possono essere figlie dirette delle righe.
 - Grazie a flexbox, le colonne della griglia senza uno specifico `width` verranno automaticamente impostate come colonne di uguale larghezza. Per esempio, quattro casi di `.col-sm` avranno automaticamente una larghezza del 25% dal più piccolo breakpoint in su. Guarda la sezione [colonne a disposizione automatica](#colonne-a-disposizione-automatica) per maggiori informazioni.
-- Le classi delle colonne indicano il numero delle colonne che dovresti utilizzare in base alle 12 possibili per riga. Quindi, se vuoi tre colonne di uguale larghezza , puoi usare `.col-4`.
+- Le classi delle colonne indicano il numero delle colonne che dovresti utilizzare in base alle 12 possibili per riga. Quindi, se vuoi tre colonne di uguale larghezza, puoi usare `.col-4`.
 - Le `width` delle colonne sono stabilite in percentuale, quindi sono sempre fluide e dimensionate rispetto al loro elemento genitore.
 - Le colonne hanno un `padding` orizzontale per creare il gutter tra le singole colonne. Per rimuovere il `margin` dalle righe e il `padding` dalle colonne aggiungendo la classe `.g-0` alla classe `.row`.
 - Per renderla responsive, esistono sei breakpoint della griglia, uno per ogni responsive breakpoint: tutti i breakpoint (extra small), small, medium, large, extra large ed extra extra large.

--- a/docs/organizzare-gli-spazi/griglie.md
+++ b/docs/organizzare-gli-spazi/griglie.md
@@ -381,7 +381,7 @@ Usa le classi reattive `.row-cols-*` per impostare rapidamente il numero di colo
 
 ## Allineamento
 
-Usa le [utilità d'allineamento]({{ site.baseurl }}/docs/organizzare-gli-spazi/flex/) di Flexbox per allineare orizzontalmente e vericalmente le colonne.
+Usa le [utilità d'allineamento]({{ site.baseurl }}/docs/organizzare-gli-spazi/flex/) di Flexbox per allineare orizzontalmente e verticalmente le colonne.
 
 ### Allineamento verticale
 

--- a/docs/organizzare-gli-spazi/introduzione.md
+++ b/docs/organizzare-gli-spazi/introduzione.md
@@ -61,7 +61,7 @@ _NB: Se si sta usando una versione di Bootstrap Italia basata su Bootstrap 4, la
 
 ## Responsive breakpoints
 
-Visto che la progettazione web è bene venga gestita _mobile-first_, in Bootstrap Italia sono definite alcune [media query](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries) per definire breakpoints ai quali il layout si modifica. Questi breakpoints sono basati sulla dimensioni minima del viewport e permettono di scalare verso l'alto quando la dimensione della finesta aumenta.
+Visto che la progettazione web è bene venga gestita _mobile-first_, in Bootstrap Italia sono definite alcune [media query](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries) per definire breakpoints ai quali il layout si modifica. Questi breakpoints sono basati sulla dimensione minima del viewport e permettono di scalare verso l'alto quando la dimensione della finestra aumenta.
 
 Bootstrap Italia utilizza le seguenti media query per definire i breakpoint usati nelle sue griglie e componenti.
 

--- a/docs/organizzare-gli-spazi/proporzioni.md
+++ b/docs/organizzare-gli-spazi/proporzioni.md
@@ -34,7 +34,7 @@ description: Obbligano un elemento a mantenere la proporzione scelta. Soluzione 
 
 Utilizza queste classi helper per gestire le proporzioni di contenuti esterni come `<iframe>`, `<embed>`, `<video>` e `<object>`. Queste classi possono inoltre essere utilizzate per ridimensionare qualsiasi elemento HTML standard come `<div>` o `<img>`. Gli stili vengono applicati dall'elemento contenitore `.ratio` all'elemento contenuto.
 
-Le proporzioni predefinite sono dichiarate in un amappa Sass ed incluse in ogni classe con una variabile CSS, la quale permette di generare [proporzioni custom](#proporzioni-custom).
+Le proporzioni predefinite sono dichiarate in una mappa Sass ed incluse in ogni classe con una variabile CSS, la quale permette di generare [proporzioni custom](#proporzioni-custom).
 
 {% capture callout %}
 

--- a/docs/organizzare-i-contenuti/immagini-sostitutive.md
+++ b/docs/organizzare-i-contenuti/immagini-sostitutive.md
@@ -19,7 +19,7 @@ Utilizza la classe `.text-hide` o il relativo mixin per sostituire del testo in 
 }
 ```
 
-Usa la classe `.text-hide` per mantere accessibile la pagina e i vantaggi SEO dei tags di intestazione pur utilizzando
+Usa la classe `.text-hide` per mantenere accessibile la pagina e i vantaggi SEO dei tags di intestazione pur utilizzando
 un'immagine di sfondo invece del testo.
 
 {% capture example %}

--- a/docs/organizzare-i-contenuti/immagini.md
+++ b/docs/organizzare-i-contenuti/immagini.md
@@ -6,7 +6,7 @@ title: Immagini
 description: Documentazione ed esempi per l'inserimento di immagini responsive, che quindi non diventano mai più grandi dei loro elementi genitore.
 ---
 
-Le immagini in Bootstrap Italia sono rese responsive con la classe `.img-fluid`, così che vengano applicate all'immagine le proporietà `max-width: 100%;` e `height: auto;` in modo che sia ridimensionata attraverso l'elemento padre.
+Le immagini in Bootstrap Italia sono rese responsive con la classe `.img-fluid`, così che vengano applicate all'immagine le proprietà `max-width: 100%;` e `height: auto;` in modo che sia ridimensionata attraverso l'elemento padre.
 
 {% comment %}Example name: Base{% endcomment %}
 {% capture example %}

--- a/docs/organizzare-i-contenuti/liste.md
+++ b/docs/organizzare-i-contenuti/liste.md
@@ -281,7 +281,7 @@ L'elemento `.it-multiple` con all'interno le relative icone, segue l'elemento `.
 Ad ogni lista si può aggiungere un campo testuale _metadata_, come nell'esempio seguente.
 L'elemento `.metadata`, segue l'elemento `.text`.
 
-{% comment %}Example name: Con medatada{% endcomment %}
+{% comment %}Example name: Con metadata{% endcomment %}
 {% capture example %}
 <div class="it-list-wrapper">
   <ul class="it-list">
@@ -572,7 +572,7 @@ Per ogni elemento di una lista di link è possibile definire una variante di dim
 
 Ogni elemento di una lista di link può avere un'icona (a destra o sinistra del testo) ed un abstract.
 
-Per includere un'icona bisogna aggiungere al tag `<a>` uan delle segeunti classi:
+Per includere un'icona bisogna aggiungere al tag `<a>` una delle seguenti classi:
 
 - `icon-right`: se si vuole posizionare l'icona a destra del testo
 - `icon-left`: se si vuole posizionare l'icona a sinistra del testo

--- a/docs/organizzare-i-contenuti/tipografia.md
+++ b/docs/organizzare-i-contenuti/tipografia.md
@@ -285,7 +285,7 @@ di un `<blockquote class="blockquote">` come la citazione.
 ### Citare una fonte
 
 Aggiungi un `<footer class="blockquote-footer">` per identificare la fonte.
-Includi il nome delle fonte di origine in `<cite>`.
+Includi il nome della fonte di origine in `<cite>`.
 
 {% comment %}Example name: Citazioni con fonte{% endcomment %}
 {% capture example %}

--- a/docs/utilities/colori-custom.md
+++ b/docs/utilities/colori-custom.md
@@ -107,7 +107,7 @@ Il colore primario possiede tre tipologie di varianti cromatiche. Per utilizzarl
 
 ### Analoghi
 
-Ai colori monocromatici può essere affiancato un accent color, definito così perche si tratta di un colore molto luminoso, serve ad attirare l’attenzione.
+Ai colori monocromatici può essere affiancato un accent color, definito così perché si tratta di un colore molto luminoso, serve ad attirare l’attenzione.
 
 Devono essere usati in modo parsimonioso.
 

--- a/docs/utilities/colori.md
+++ b/docs/utilities/colori.md
@@ -14,7 +14,7 @@ description: Una serie di classi di utilità per applicare colori a testi e sfon
 Il colore è uno degli strumenti principali per la trasmissione delle informazioni, ma non dimenticare mai di affiancare all'uso del colore altri mezzi più espliciti. 
 {% endcapture %}{% include callout.html content=callout type="accessibility" %}
 
-Bootstrap Italia eredita gli stessi meccanisimi per la gestione dei colori di Bootstrap {{ site.bootstrap_version }}, dove i colori del tema sono descritti attraverso una variabile Sass nominata `$theme-colors`.
+Bootstrap Italia eredita gli stessi meccanismi per la gestione dei colori di Bootstrap {{ site.bootstrap_version }}, dove i colori del tema sono descritti attraverso una variabile Sass nominata `$theme-colors`.
 
 La principale novità introdotta da Bootstrap Italia è una serie di varianti della tonalità primaria _primary_ basate sullo spazio colore [HSB](https://it.wikipedia.org/wiki/Hue_Saturation_Brightness) (coincidente con il modello HSV).
 
@@ -36,7 +36,7 @@ Puoi trovare maggiori informazioni sulla palette di colori a disposizione alla p
 
 ## Colore di sfondo
 
-Allo stesso modo di quanto avviene per il testo, le classi `bg-*` permettono di colorare lo sfondo di un elemento; le classi per gli sfondi **non hanno alcun impatto sulla proprità `color`**, per cui in alcuni casi sarà necessario affiancarle alle classi `.text-*`.
+Allo stesso modo di quanto avviene per il testo, le classi `bg-*` permettono di colorare lo sfondo di un elemento; le classi per gli sfondi **non hanno alcun impatto sulla proprietà `color`**, per cui in alcuni casi sarà necessario affiancarle alle classi `.text-*`.
 
 {% comment %}Example name: Sfondo{% endcomment %}
 {% capture example %}


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Ho trovato e risolto diversi errori di battitura e di grammatica presenti nella documentazione.
I fix riguardano singole parole, e sono tutti raggruppati per tipologia nei singoli commit (es: fix accenti).

Fixes #958 

## Checklist

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
