### PR TITLE
Rimuovere spazio bianco nel link "Torna indietro"

### DIFF
--- a/api/menu-di-navigazione/torna-indietro.json
+++ b/api/menu-di-navigazione/torna-indietro.json
@@ -1,11 +1,11 @@
 [
     {
         "name": "Link",
-        "content": "\n<a href=\"#\" class=\"go-back\" data-bs-toggle=\"historyback\"><svg class=\"icon icon-sm icon-primary me-2\"><use href=\"/dist/svg/sprites.svg#it-arrow-left\"></use></svg> Torna indietro</a>\n"
+        "content": "\n<a href=\"#\" class=\"go-back\" data-bs-toggle=\"historyback\"><svg class=\"icon icon-sm icon-primary me-2\"><use href=\"/dist/svg/sprites.svg#it-arrow-left\"></use></svg>Torna indietro</a>\n"
     },
     {
         "name": "Pulsanti con freccia",
-        "content": "\n<button type=\"button\" class=\"btn btn-primary go-back\" data-bs-toggle=\"historyback\"><svg class=\"icon icon-sm icon-white me-2\"><use href=\"/dist/svg/sprites.svg#it-arrow-left\"></use></svg> Torna indietro</button>\n<button type=\"button\" class=\"btn btn-primary go-back\" data-bs-toggle=\"historyback\"><svg class=\"icon icon-sm icon-white me-2\"><use href=\"/dist/svg/sprites.svg#it-arrow-up\"></use></svg> Livello superiore</button>\n"
+        "content": "\n<button type=\"button\" class=\"btn btn-primary go-back\" data-bs-toggle=\"historyback\"><svg class=\"icon icon-sm icon-white me-2\"><use href=\"/dist/svg/sprites.svg#it-arrow-left\"></use></svg>Torna indietro</button>\n<button type=\"button\" class=\"btn btn-primary go-back\" data-bs-toggle=\"historyback\"><svg class=\"icon icon-sm icon-white me-2\"><use href=\"/dist/svg/sprites.svg#it-arrow-up\"></use></svg> Livello superiore</button>\n"
     },
     {
         "name": "Pulsanti, solo icona",


### PR DESCRIPTION
## Descrizione

Ho notato che il link "Torna indietro" in due casi presentava uno spazio bianco prima della parola "Torna". Li ho quindi rimossi.

## Checklist

- [X] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [X] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [X] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [X] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [X] La documentazione è stata aggiornata.
