### PR TITLE
Fix chips margins

### DIFF
--- a/docs/componenti/chips.md
+++ b/docs/componenti/chips.md
@@ -153,7 +153,6 @@ I gruppi di chip vengono visualizzati in linea.
 <div class="chip chip-simple">
   <span class="chip-label">Label</span>
 </div>
-
 <div class="chip">
   <span class="chip-label">Label</span>
   <button>
@@ -161,7 +160,6 @@ I gruppi di chip vengono visualizzati in linea.
     <span class="visually-hidden">Elimina label</span>
   </button>
 </div>
-
 <div class="chip">
   <svg class="icon icon-xs"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-github"></use></svg>
   <span class="chip-label">Label</span>
@@ -170,7 +168,6 @@ I gruppi di chip vengono visualizzati in linea.
     <span class="visually-hidden">Elimina label</span>
   </button>
 </div>
-
 <div class="chip">
   <div class="avatar size-xs">
     <img src="https://randomuser.me/api/portraits/men/46.jpg" alt="Mario Rossi">
@@ -187,7 +184,6 @@ I gruppi di chip vengono visualizzati in linea.
 <div class="chip chip-lg chip-simple">
   <span class="chip-label">Label</span>
 </div>
-
 <div class="chip chip-lg">
   <span class="chip-label">Label</span>
   <button>
@@ -195,7 +191,6 @@ I gruppi di chip vengono visualizzati in linea.
     <span class="visually-hidden">Elimina label</span>
   </button>
 </div>
-
 <div class="chip chip-lg">
   <svg class="icon icon-xs"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-github"></use></svg>
   <span class="chip-label">Label</span>
@@ -204,7 +199,6 @@ I gruppi di chip vengono visualizzati in linea.
     <span class="visually-hidden">Elimina label</span>
   </button>
 </div>
-
 <div class="chip chip-lg">
   <div class="avatar size-xs">
     <img src="https://randomuser.me/api/portraits/men/46.jpg" alt="Mario Rossi">

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -586,6 +586,8 @@ $chips-background: $color-background-muted !default; // UI kit
 $chips-background-hover: $color-background-secondary-hover !default; // UI kit
 $chips-label-color: $color-text-secondary !default; // UI kit
 $chips-label-color-disabled: $gray-label-disabled !default; // UI kit
+$chips-label-font-size: 0.875rem;
+$chips-label-font-size-l: 1rem;
 $chips-border: $color-border-subtle !default;
 
 // stepper

--- a/src/scss/custom/_chips.scss
+++ b/src/scss/custom/_chips.scss
@@ -10,10 +10,15 @@
   min-width: 100px;
   padding: 0 $v-gap * 2 2px $v-gap;
   transition: all 0.05s;
-  margin: $v-gap * 0.5 $v-gap $v-gap 0px;
+  margin-top: $v-gap;
+  margin-bottom: $v-gap;
+
+  & + & {
+    margin-left: $v-gap;
+  }
   //label
   .chip-label {
-    font-size: 0.875rem;
+    font-size: $chips-label-font-size;
     height: $v-gap * 2;
     font-weight: 600;
     color: $chips-label-color;
@@ -69,7 +74,7 @@
     padding: 2px $v-gap * 3 0 $v-gap * 2;
     //label
     .chip-label {
-      font-size: 1rem;
+      font-size: $chips-label-font-size-l;
       height: 12px;
       transform: translateY(-8px);
     }

--- a/src/scss/custom/_chips.scss
+++ b/src/scss/custom/_chips.scss
@@ -10,7 +10,7 @@
   min-width: 100px;
   padding: 0 $v-gap * 2 2px $v-gap;
   transition: all 0.05s;
-  margin: $v-gap * 0.5 $v-gap * 0.5 $v-gap auto;
+  margin: $v-gap * 0.5 $v-gap $v-gap 0px;
   //label
   .chip-label {
     font-size: 0.875rem;

--- a/src/scss/custom/_chips.scss
+++ b/src/scss/custom/_chips.scss
@@ -10,11 +10,10 @@
   min-width: 100px;
   padding: 0 $v-gap * 2 2px $v-gap;
   transition: all 0.05s;
-  margin-top: $v-gap;
+  margin-top: $v-gap * 0.5;
   margin-bottom: $v-gap;
-
-  & + & {
-    margin-left: $v-gap;
+  &:not(:last-child) {
+    margin-right: $v-gap;
   }
   //label
   .chip-label {


### PR DESCRIPTION
C'è un bug di allineamento orizzontale quando le Chips sono in gruppo, scoperto sviluppando il sito Designers Italia. Vedi fix temporaneo realizzato qui https://github.com/italia/designers.italia.it/pull/1101

@zetareticoli modifica/integra come credi. E testiamola su tutti i browser/device. 


----
{New PR from the original one here: https://github.com/italia/bootstrap-italia/pull/1020 }