### PR TITLE
fix: refactor lint spacing and newlines around files

### DIFF
--- a/docs/componenti/alert.md
+++ b/docs/componenti/alert.md
@@ -76,9 +76,7 @@ Clicca sul pulsante di chiusura per vedere la funzionalità di rimozione alert i
 <div class="alert alert-warning alert-dismissible fade show" role="alert">
   <strong>Attenzione</strong> Alcuni campi inseriti sono da controllare.
   <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Chiudi avviso">
-    <svg class="icon">
-      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-    </svg>
+    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
   </button>
 </div>
 {% endcapture %}

--- a/docs/componenti/buttons.md
+++ b/docs/componenti/buttons.md
@@ -94,47 +94,23 @@ La classe `.disabled` usa `pointer-events: none` per provare a disabilitare l'at
 {% comment %}Example name: Con icona{% endcomment %}
 {% capture example %}
 <button class="btn btn-success btn-lg btn-icon btn-me">
-<span>Icon Button Lg</span>
-<svg class="icon icon-white ms-1">
-<use
-        href="{{
-          site.baseurl
-        }}/dist/svg/sprites.svg#it-star-full"
-      ></use>
-</svg>
+  <span>Icon Button Lg</span>
+  <svg class="icon icon-white ms-1"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-star-full"></use></svg>
 </button>
 
 <button class="btn btn-primary btn-icon btn-me">
   <span>Icon Button</span>
-  <svg class="icon icon-white ms-1">
-  <use
-        href="{{
-          site.baseurl
-        }}/dist/svg/sprites.svg#it-star-full"
-      ></use>
-  </svg>
+  <svg class="icon icon-white ms-1"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-star-full"></use></svg>
 </button>
 
 <button class="btn btn-danger btn-sm btn-icon btn-me">
   <span>Icon Button Sm</span>
-  <svg class="icon icon-white ms-1">
-  <use
-        href="{{
-          site.baseurl
-        }}/dist/svg/sprites.svg#it-star-full"
-      ></use>
-  </svg>
+  <svg class="icon icon-white ms-1"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-star-full"></use></svg>
 </button>
 
 <button class="btn btn-info btn-xs btn-icon ms-1">
   <span>Icon Button Xs</span>
-  <svg class="icon icon-white">
-  <use
-        href="{{
-          site.baseurl
-        }}/dist/svg/sprites.svg#it-star-full"
-      ></use>
-  </svg>
+  <svg class="icon icon-white ms-1"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-star-full"></use></svg>
 </button>
 {% endcapture %}{% include example.html content=example %}
 
@@ -147,39 +123,31 @@ Inoltre è possibile applicare un contorno cerchiato dell'icona utilizzando un c
 {% comment %}Example name: Con icona, cerchiata{% endcomment %}
 {% capture example %}
 <button class="btn btn-success btn-lg btn-icon btn-me">
-<span class="rounded-icon">
-<svg class="icon icon-success">
-<use href="{{site.baseurl}}/dist/svg/sprites.svg#it-user"></use>
-</svg>
-</span>
-<span>Round Icon Lg</span>
+  <span class="rounded-icon">
+    <svg class="icon icon-success"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-user"></use></svg>
+  </span>
+  <span>Round Icon Lg</span>
 </button>
 
 <button class="btn btn-primary btn-icon btn-me">
-<span class="rounded-icon">
-<svg class="icon icon-primary">
-<use href="{{site.baseurl}}/dist/svg/sprites.svg#it-user"></use>
-</svg>
-</span>
-<span>Round Icon</span>
+  <span class="rounded-icon">
+    <svg class="icon icon-primary"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-user"></use></svg>
+  </span>
+  <span>Round Icon</span>
 </button>
 
 <button class="btn btn-danger btn-sm btn-icon btn-me">
-<span class="rounded-icon">
-<svg class="icon icon-danger">
-<use href="{{site.baseurl}}/dist/svg/sprites.svg#it-user"></use>
-</svg>
-</span>
-<span>Round Icon Sm</span>
+  <span class="rounded-icon">
+    <svg class="icon icon-danger"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-user"></use></svg>
+  </span>
+  <span>Round Icon Sm</span>
 </button>
 
 <button class="btn btn-secondary btn-xs btn-icon">
-<span class="rounded-icon">
-<svg class="icon icon-secondary">
-<use href="{{site.baseurl}}/dist/svg/sprites.svg#it-user"></use>
-</svg>
-</span>
-<span>Round Icon Xs</span>
+  <span class="rounded-icon">
+    <svg class="icon icon-secondary"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-user"></use></svg>
+  </span>
+  <span>Round Icon Xs</span>
 </button>
 {% endcapture %}{% include example.html content=example %}
 

--- a/docs/componenti/card.md
+++ b/docs/componenti/card.md
@@ -121,9 +121,7 @@ Quando si utilizzano link con label generiche come “Leggi tutto” o “Leggi 
           <a class="read-more" href="#">
             <span class="text">Leggi di più</span>
             <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
           </a>
         </div>
       </div>
@@ -147,9 +145,7 @@ Per inserire la categorizzazione con relativa icona, usare l'elemento `.category
       <div class="card">
         <div class="card-body">
           <div class="categoryicon-top">
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-file"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-file"></use></svg>
             <span class="text">Categoria<br>nome</span>
           </div>
           <a href="#">
@@ -181,9 +177,7 @@ segue il paragrafo.
       <div class="card">
         <div class="card-body">
           <div class="categoryicon-top">
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-copy"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-copy"></use></svg>
             <span class="text">(2) File</span>
           </div>
           <a href="#">
@@ -220,9 +214,7 @@ Le card con ombreggiatura sono caratterizzate dalle classi:
           <a class="read-more" href="#">
             <span class="text">Leggi di più</span>
             <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
           </a>
         </div>
       </div>
@@ -253,18 +245,14 @@ il div contenente l'icona è di classe `.top-icon`.
       <div class="card card-bg card-big">
         <div class="card-body">
           <div class="top-icon">
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-card"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-card"></use></svg>
           </div>
           <h3 class="card-title h5 no_toc">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</h3>
           <p class="card-text font-serif">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
           <a class="read-more" href="#">
             <span class="text">Leggi di più</span>
             <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
           </a>
         </div>
       </div>
@@ -290,9 +278,7 @@ Per creare un bordo di colore primario a chiusura card, potete utilizzare la cla
       <div class="card card-bg card-big border-bottom-card">
         <div class="flag-icon"></div>
         <div class="etichetta">
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-settings"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-settings"></use></svg>
           <span>Sviluppo</span>
         </div>
         <div class="card-body">
@@ -301,9 +287,7 @@ Per creare un bordo di colore primario a chiusura card, potete utilizzare la cla
           <a class="read-more" href="#">
             <span class="text">Leggi di più</span>
             <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
           </a>
         </div>
       </div>
@@ -375,9 +359,7 @@ Qualora le proporzioni non fossero esatte, l'immagine occuperà il massimo dell'
           <a class="read-more" href="#">
             <span class="text">Leggi di più</span>
             <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
           </a>
         </div>
       </div>
@@ -401,9 +383,7 @@ Qualora le proporzioni non fossero esatte, l'immagine occuperà il massimo dell'
           <a class="read-more" href="#">
             <span class="text">Leggi di più</span>
             <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-            </svg></a>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg></a>
         </div>
       </div>
     </div>
@@ -430,9 +410,7 @@ Qualora le proporzioni non fossero esatte, l'immagine occuperà il massimo dell'
               <a class="read-more" href="#">
               <span class="text">Leggi di più</span>
               <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span>
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-              </svg></a>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg></a>
           </div>
         </div>
       </div>
@@ -459,9 +437,7 @@ Qualora le proporzioni non fossero esatte, l'immagine occuperà il massimo dell'
               <a class="read-more" href="#">
               <span class="text">Leggi di più</span>
               <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span>
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-              </svg></a>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg></a>
           </div>
         </div>
       </div>
@@ -531,9 +507,7 @@ Come per ogni elemento, è possibile aggiungere le classi `rounded` o `shadow` p
   <div class="card card-teaser rounded shadow">
     <div class="card-body">
       <h3 class="card-title h5 no_toc">
-        <svg class="icon">
-          <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clip"></use>
-        </svg>
+        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clip"></use></svg>
         <a href="#">Lorem ipsum dolor sit amet</a>
       </h3>
       <div class="card-text font-serif">

--- a/docs/componenti/carousel.md
+++ b/docs/componenti/carousel.md
@@ -73,9 +73,7 @@ Esempio di carousel con card semplici.
                 <p class="card-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">1. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>
@@ -91,9 +89,7 @@ Esempio di carousel con card semplici.
                 <p class="card-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">1. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>
@@ -109,9 +105,7 @@ Esempio di carousel con card semplici.
                 <p class="card-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">1. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>
@@ -127,9 +121,7 @@ Esempio di carousel con card semplici.
                 <p class="card-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">1. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>
@@ -145,9 +137,7 @@ Esempio di carousel con card semplici.
                 <p class="card-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">1. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>
@@ -163,9 +153,7 @@ Esempio di carousel con card semplici.
                 <p class="card-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">1. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>
@@ -203,9 +191,7 @@ Esempio di carousel con card semplici.
                 <span class="card-signature">di Federico De Paolis</span>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>
@@ -226,9 +212,7 @@ Esempio di carousel con card semplici.
                 <span class="card-signature">di Federico De Paolis</span>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>
@@ -249,9 +233,7 @@ Esempio di carousel con card semplici.
                 <span class="card-signature">di Federico De Paolis</span>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>
@@ -272,9 +254,7 @@ Esempio di carousel con card semplici.
                 <span class="card-signature">di Federico De Paolis</span>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>
@@ -322,9 +302,7 @@ Contiene un'immagine associata ad una card "articolo".
                   <span class="card-signature">di Federico De Paolis</span>
                   <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span></span>
-                    <svg class="icon">
-                      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -354,9 +332,7 @@ Contiene un'immagine associata ad una card "articolo".
                   <span class="card-signature">di Federico De Paolis</span>
                   <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span></span>
-                    <svg class="icon">
-                      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -386,9 +362,7 @@ Contiene un'immagine associata ad una card "articolo".
                   <span class="card-signature">di Federico De Paolis</span>
                   <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span></span>
-                    <svg class="icon">
-                      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -426,9 +400,7 @@ Contiene un'immagine associata ad una card "articolo".
                 <h5 class="card-title">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</h5>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>
@@ -448,9 +420,7 @@ Contiene un'immagine associata ad una card "articolo".
                 <h5 class="card-title">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</h5>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>
@@ -470,9 +440,7 @@ Contiene un'immagine associata ad una card "articolo".
                 <h5 class="card-title">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</h5>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>
@@ -492,9 +460,7 @@ Contiene un'immagine associata ad una card "articolo".
                 <h5 class="card-title">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</h5>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>
@@ -514,9 +480,7 @@ Contiene un'immagine associata ad una card "articolo".
                 <h5 class="card-title">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</h5>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>
@@ -536,9 +500,7 @@ Contiene un'immagine associata ad una card "articolo".
                 <h5 class="card-title">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</h5>
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più <span class="visually-hidden">Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span></span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>

--- a/docs/componenti/hero.md
+++ b/docs/componenti/hero.md
@@ -251,9 +251,7 @@ Aggiungere alla section `.it-hero-wrapper` la classe `.it-bottom-overlapping-con
                       <a class="read-more" href="#">
                         <span class="text">Leggi di più</span>
                         <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</span>
-                        <svg class="icon">
-                            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                        </svg>
+                        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                       </a>
                     </div>
                   </div>

--- a/docs/componenti/modale.md
+++ b/docs/componenti/modale.md
@@ -99,9 +99,7 @@ Per chiudere la modale, si può utilizzare un pulsante con classe `.btn-close`.
 {% comment %}Example name: Pulsante di chiusura, dettaglio{% endcomment %}
 {% capture example %}
 <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Chiudi finestra modale">
-<svg class="icon">
-<use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-</svg>
+  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
 </button>
 {% endcapture %}{% include example.html content=example %}
 

--- a/docs/componenti/modale.md
+++ b/docs/componenti/modale.md
@@ -116,9 +116,7 @@ Esempio completo:
             <div class="modal-header">
                <h2 class="modal-title h5 no_toc" id="modal2Title">Questo è un messaggio di notifica</h2>
                <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Chiudi finestra modale">
-                  <svg class="icon">
-                     <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
                </button>
             </div>
             <div class="modal-body">
@@ -145,9 +143,7 @@ Per formattare correttamente i contenuti della modale con icona, occorre aggiung
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use></svg>
           <h2 class="modal-title h5 no_toc" id="modal3Title">Questo è un messaggio di notifica più esteso del solito</h2>
         </div>
         <div class="modal-body">
@@ -176,9 +172,7 @@ Di seguito una modale con un elenco di radio button.
             <div class="modal-header">
                <h2 class="modal-title h5 no_toc" id="modal4Title">Scegli una opzione</h2>
                <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Chiudi finestra modale">
-                  <svg class="icon">
-                     <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
                </button>
             </div>
             <div class="modal-body">
@@ -353,9 +347,7 @@ Per meglio distinguere l'elemento _footer_ con un'ombra è sufficiente aggiunger
       <div class="modal-header">
         <h2 class="modal-title h5 no_toc" id="exampleModalLongTitle">Intestazione modale</h2>
         <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Chiudi finestra modale">
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
         </button>
       </div>
       <div class="modal-body">
@@ -460,9 +452,7 @@ Aggiungi `.modal-dialog-centered` a `.modal-dialog` per centrare verticalmente l
       <div class="modal-header">
         <h2 class="modal-title h5 no_toc" id="modalCenterTitle">Questo è un messaggio di notifica</h2>
         <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Chiudi finestra modale">
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
         </button>
       </div>
       <div class="modal-body">
@@ -494,9 +484,7 @@ Aggiungi `.modal-dialog-left` a `.modal-dialog` per allineare a sinistra la moda
       <div class="modal-header">
         <h2 class="modal-title h5 no_toc" id="modalLeftTitle">Questo è un messaggio di notifica</h2>
         <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Chiudi finestra modale">
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
         </button>
       </div>
       <div class="modal-body">
@@ -550,9 +538,7 @@ Aggiungi `.modal-dialog-right` a `.modal-dialog` per allineare a sinistra la mod
       <div class="modal-header">
         <h2 class="modal-title h5 no_toc" id="modalrightTitle">Questo è un messaggio di notifica</h2>
         <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Chiudi finestra modale">
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
         </button>
       </div>
       <div class="modal-body">

--- a/docs/componenti/sticky.md
+++ b/docs/componenti/sticky.md
@@ -156,18 +156,14 @@ In tal caso è necessario utilizzare l'attributo `data-bs-target`.
             <!--start nav-->
             <nav class="navbar navbar-expand-lg has-megamenu" aria-label="Navigazione principale">
               <button class="custom-navbar-toggler" type="button" aria-controls="navC1" aria-expanded="false" aria-label="Mostra/Nascondi la navigazione" data-bs-toggle="navbarcollapsible" data-bs-target="#navC1">
-                <svg class="icon">
-                  <use href="/dist/svg/sprites.svg#it-burger"></use>
-                </svg>
+                <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-burger"></use></svg>
               </button>
               <div class="navbar-collapsable" id="navC1" style="display: none;">
                 <div class="overlay" style="display: none;"></div>
                 <div class="close-div">
                   <button class="btn close-menu" type="button">
                     <span class="visually-hidden">Nascondi la navigazione</span>
-                    <svg class="icon">
-                      <use href="/dist/svg/sprites.svg#it-close-big"></use>
-                    </svg>
+                    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close-big"></use></svg>
                   </button>
                 </div>
                 <div class="menu-wrapper">

--- a/docs/componenti/tab.md
+++ b/docs/componenti/tab.md
@@ -58,33 +58,25 @@ Le label dei tab possono essere sostituite da icone con classi che ne indicano i
 <ul class="nav nav-tabs auto">
   <li class="nav-item">
     <a class="nav-link active" aria-current="page">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use></svg>
       <span class="visually-hidden">Tab titolo 1</span>
     </a>
   </li>
   <li class="nav-item">
     <a class="nav-link">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use></svg>
       <span class="visually-hidden">Tab titolo 2</span>
     </a>
   </li>
   <li class="nav-item">
     <a class="nav-link">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-comment"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-comment"></use></svg>
       <span class="visually-hidden">Tab titolo 3</span>
     </a>
   </li>
   <li class="nav-item">
     <a class="nav-link disabled" tabindex="-1">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
       <span class="visually-hidden">Tab titolo 4</span>
     </a>
   </li>
@@ -142,33 +134,25 @@ Icone e testi possono convivere all'interno dei tab, l'allineamento verticale de
 <ul class="nav nav-tabs nav-tabs-icon-text auto">
   <li class="nav-item">
     <a class="nav-link active" aria-current="page">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use></svg>
       Tab 1
     </a>
   </li>
   <li class="nav-item">
     <a class="nav-link">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use></svg>
       Tab 2
     </a>
   </li>
   <li class="nav-item">
     <a class="nav-link">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-comment"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-comment"></use></svg>
       Tab 3
     </a>
   </li>
   <li class="nav-item">
     <a class="nav-link disabled" tabindex="-1">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
       Tab 4
     </a>
   </li>
@@ -198,33 +182,25 @@ In assenza della classe `.auto` i tab vengono dimensionati in base al contenuto.
 <ul class="nav nav-tabs">
   <li class="nav-item">
     <a class="nav-link active" aria-current="page">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use></svg>
       <span class="visually-hidden">Tab titolo 1</span>
     </a>
   </li>
   <li class="nav-item">
     <a class="nav-link">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use></svg>
       <span class="visually-hidden">Tab titolo 2</span>
     </a>
   </li>
   <li class="nav-item">
     <a class="nav-link">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-comment"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-comment"></use></svg>
       <span class="visually-hidden">Tab titolo 3</span>
     </a>
   </li>
   <li class="nav-item">
     <a class="nav-link disabled" tabindex="-1">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
       <span class="visually-hidden">Tab titolo 4</span>
     </a>
   </li>
@@ -278,33 +254,25 @@ In assenza della classe `.auto` i tab vengono dimensionati in base al contenuto.
 <ul class="nav nav-tabs nav-tabs-icon-text">
   <li class="nav-item">
     <a class="nav-link active" aria-current="page">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use></svg>
       Tab 1
     </a>
   </li>
   <li class="nav-item">
     <a class="nav-link">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use></svg>
       Tab 2
     </a>
   </li>
   <li class="nav-item">
     <a class="nav-link">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-comment"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-comment"></use></svg>
       Tab 3
     </a>
   </li>
   <li class="nav-item">
     <a class="nav-link disabled" tabindex="-1">
-      <svg class="icon">
-        <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-      </svg>
+      <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
       Tab 4
     </a>
   </li>
@@ -334,57 +302,43 @@ Se i tab contengono icone è necessario aggiungere un'ulteriore classe al wrappe
   <ul class="nav nav-tabs nav-tabs-icon-text">
     <li class="nav-item">
       <a class="nav-link active" aria-current="page">
-        <svg class="icon">
-          <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use>
-        </svg>
+        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use></svg>
         Tab 1
       </a>
     </li>
     <li class="nav-item">
       <a class="nav-link">
-        <svg class="icon">
-          <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use>
-        </svg>
+        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use></svg>
         Tab 2
       </a>
     </li>
     <li class="nav-item">
       <a class="nav-link">
-        <svg class="icon">
-          <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use>
-        </svg>
+        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use></svg>
         Tab 3
       </a>
     </li>
     <li class="nav-item">
       <a class="nav-link">
-        <svg class="icon">
-          <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use>
-        </svg>
+        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use></svg>
         Tab 4
       </a>
     </li>
     <li class="nav-item">
       <a class="nav-link">
-        <svg class="icon">
-          <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use>
-        </svg>
+        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use></svg>
         Tab 5
       </a>
     </li>
     <li class="nav-item">
       <a class="nav-link">
-        <svg class="icon">
-          <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use>
-        </svg>
+        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use></svg>
         Tab 6
       </a>
     </li>
     <li class="nav-item">
       <a class="nav-link">
-        <svg class="icon">
-          <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use>
-        </svg>
+        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use></svg>
         Tab 7
       </a>
     </li>

--- a/docs/componenti/timeline.md
+++ b/docs/componenti/timeline.md
@@ -29,9 +29,7 @@ Il **PIN** ha tre varianti di classe per il suo contenitore `.it-pin-wrapper`:
       <div class="timeline-element">
         <div class="it-pin-wrapper it-evidence">
           <div class="pin-icon">
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </div>
           <div class="pin-text"><span>maggio {{'now' | date: "%Y"}}</span></div>
         </div>
@@ -47,9 +45,7 @@ Il **PIN** ha tre varianti di classe per il suo contenitore `.it-pin-wrapper`:
               <span class="card-signature">di Federico De Paolis</span>
               <a class="read-more" href="#">
                 <span class="text">Leggi di più</span>
-                <svg class="icon">
-                  <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                </svg>
+                <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
               </a>
             </div>
           </div>
@@ -60,9 +56,7 @@ Il **PIN** ha tre varianti di classe per il suo contenitore `.it-pin-wrapper`:
       <div class="timeline-element">
         <div class="it-pin-wrapper it-evidence">
           <div class="pin-icon">
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </div>
           <div class="pin-text"><span>giugno {{'now' | date: "%Y"}}</span></div>
         </div>
@@ -80,9 +74,7 @@ Il **PIN** ha tre varianti di classe per il suo contenitore `.it-pin-wrapper`:
       <div class="timeline-element">
         <div class="it-pin-wrapper it-evidence">
           <div class="pin-icon">
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </div>
           <div class="pin-text"><span>luglio {{'now' | date: "%Y"}}</span></div>
         </div>
@@ -99,9 +91,7 @@ Il **PIN** ha tre varianti di classe per il suo contenitore `.it-pin-wrapper`:
               <a class="read-more" href="#">
                 <span class="text">Leggi di più</span>
                 <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span>
-                <svg class="icon">
-                  <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                </svg>
+                <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
               </a>
             </div>
           </div>
@@ -113,9 +103,7 @@ Il **PIN** ha tre varianti di classe per il suo contenitore `.it-pin-wrapper`:
         <span class="it-now-label d-none d-lg-flex">Oggi</span>
         <div class="it-pin-wrapper it-now">
           <div class="pin-icon">
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </div>
           <div class="pin-text"><span>agosto {{'now' | date: "%Y"}}</span></div>
         </div>
@@ -133,9 +121,7 @@ Il **PIN** ha tre varianti di classe per il suo contenitore `.it-pin-wrapper`:
       <div class="timeline-element">
         <div class="it-pin-wrapper">
           <div class="pin-icon">
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </div>
           <div class="pin-text"><span>settembre {{'now' | date: "%Y"}}</span></div>
         </div>
@@ -152,9 +138,7 @@ Il **PIN** ha tre varianti di classe per il suo contenitore `.it-pin-wrapper`:
               <a class="read-more" href="#">
                 <span class="text">Leggi di più</span>
                 <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span>
-                <svg class="icon">
-                  <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                </svg>
+                <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
               </a>
             </div>
           </div>
@@ -165,9 +149,7 @@ Il **PIN** ha tre varianti di classe per il suo contenitore `.it-pin-wrapper`:
       <div class="timeline-element">
         <div class="it-pin-wrapper">
           <div class="pin-icon">
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </div>
           <div class="pin-text"><span>ottobre {{'now' | date: "%Y"}}</span></div>
         </div>
@@ -185,9 +167,7 @@ Il **PIN** ha tre varianti di classe per il suo contenitore `.it-pin-wrapper`:
       <div class="timeline-element">
         <div class="it-pin-wrapper">
           <div class="pin-icon">
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </div>
           <div class="pin-text"><span>novembre {{'now' | date: "%Y"}}</span></div>
         </div>
@@ -204,9 +184,7 @@ Il **PIN** ha tre varianti di classe per il suo contenitore `.it-pin-wrapper`:
               <a class="read-more" href="#">
                 <span class="text">Leggi di più</span>
                 <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span>
-                <svg class="icon">
-                  <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                </svg>
+                <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
               </a>
             </div>
           </div>
@@ -217,9 +195,7 @@ Il **PIN** ha tre varianti di classe per il suo contenitore `.it-pin-wrapper`:
       <div class="timeline-element">
         <div class="it-pin-wrapper">
           <div class="pin-icon">
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </div>
           <div class="pin-text"><span>dicembre {{'now' | date: "%Y"}}</span></div>
         </div>

--- a/docs/esempi/comuni/index.html
+++ b/docs/esempi/comuni/index.html
@@ -18,8 +18,7 @@ title: Template Amministrazione
             <li>
               <a href="template-homepage/" target="_blank" class="list-item">
                 <div class="it-right-zone">
-                  <span class="text"
-                    >Homepage
+                  <span class="text">Homepage
                     <em>Esempio di homepage</em>
                   </span>
                   <span class="it-multiple"><span class="metadata">Apri in una nuova pagina</span></span>
@@ -29,8 +28,8 @@ title: Template Amministrazione
             <li>
               <a href="template-amministrazione/" target="_blank" class="list-item">
                 <div class="it-right-zone">
-                  <span class="text"
-                    >Pagina di primo livello - Amministrazione
+                  <span class="text">
+                    Pagina di primo livello - Amministrazione
                     <em>Esempio di pagina di primo livello per il menu "Amministrazione"</em>
                   </span>
                   <span class="it-multiple"><span class="metadata">Apri in una nuova pagina</span></span>
@@ -40,8 +39,8 @@ title: Template Amministrazione
             <li>
               <a href="template-servizi/" target="_blank" class="list-item">
                 <div class="it-right-zone">
-                  <span class="text"
-                    >Pagina di primo livello - Servizi
+                  <span class="text">
+                    Pagina di primo livello - Servizi
                     <em>Esempio di pagina di primo livello per il menu "Servizi"</em>
                   </span>
                   <span class="it-multiple"><span class="metadata">Apri in una nuova pagina</span></span>
@@ -51,8 +50,8 @@ title: Template Amministrazione
             <li>
               <a href="template-novita/" target="_blank" class="list-item">
                 <div class="it-right-zone">
-                  <span class="text"
-                    >Pagina di primo livello - Novità
+                  <span class="text">
+                    Pagina di primo livello - Novità
                     <em>Esempio di pagina di primo livello per il menu "Novità"</em>
                   </span>
                   <span class="it-multiple"><span class="metadata">Apri in una nuova pagina</span></span>
@@ -62,8 +61,8 @@ title: Template Amministrazione
             <li>
               <a href="template-documenti/" target="_blank" class="list-item">
                 <div class="it-right-zone">
-                  <span class="text"
-                    >Pagina di primo livello - Documenti
+                  <span class="text">
+                    Pagina di primo livello - Documenti
                     <em>Esempio di pagina di primo livello per il menu "Documenti"</em>
                   </span>
                   <span class="it-multiple"><span class="metadata">Apri in una nuova pagina</span></span>
@@ -73,8 +72,8 @@ title: Template Amministrazione
             <li>
               <a href="template-novita-evento/" target="_blank" class="list-item">
                 <div class="it-right-zone">
-                  <span class="text"
-                    >Pagina di secondo livello - Evento
+                  <span class="text">
+                    Pagina di secondo livello - Evento
                     <em>Esempio di pagina di pagina di secondo livello del menu Novità: Evento</em>
                   </span>
                   <span class="it-multiple"><span class="metadata">Apri in una nuova pagina</span></span>
@@ -84,8 +83,8 @@ title: Template Amministrazione
             <li>
               <a href="template-novita-notizia/" target="_blank" class="list-item">
                 <div class="it-right-zone">
-                  <span class="text"
-                    >Pagina di secondo livello - Notizia
+                  <span class="text">
+                    Pagina di secondo livello - Notizia
                     <em>Esempio di pagina di pagina di secondo livello del menu Novità: Notizia</em>
                   </span>
                   <span class="it-multiple"><span class="metadata">Apri in una nuova pagina</span></span>
@@ -95,8 +94,8 @@ title: Template Amministrazione
             <li>
               <a href="template-servizi-servizio/" target="_blank" class="list-item">
                 <div class="it-right-zone">
-                  <span class="text"
-                    >Pagina di secondo livello - Servizio
+                  <span class="text">
+                    Pagina di secondo livello - Servizio
                     <em>Esempio di pagina di secondo livello del menu Servizi: Servizio</em>
                   </span>
                   <span class="it-multiple"><span class="metadata">Apri in una nuova pagina</span></span>
@@ -106,8 +105,8 @@ title: Template Amministrazione
             <li>
               <a href="template-argomenti/" target="_blank" class="list-item">
                 <div class="it-right-zone">
-                  <span class="text"
-                    >Pagina di primo livello - Lista Argomenti
+                  <span class="text">
+                    Pagina di primo livello - Lista Argomenti
                     <em>Esempio di pagina di primo livello del menu "Tutti gli argomenti"</em>
                   </span>
                   <span class="it-multiple"><span class="metadata">Apri in una nuova pagina</span></span>
@@ -117,8 +116,8 @@ title: Template Amministrazione
             <li>
               <a href="template-argomenti-argomento/" target="_blank" class="list-item">
                 <div class="it-right-zone">
-                  <span class="text"
-                    >Pagina di secondo livello - Argomento
+                  <span class="text">
+                    Pagina di secondo livello - Argomento
                     <em>Esempio di pagina di secondo livello del menu Argomenti: Argomento</em>
                   </span>
                   <span class="it-multiple"><span class="metadata">Apri in una nuova pagina</span></span>
@@ -128,8 +127,8 @@ title: Template Amministrazione
             <li>
               <a href="template-risultato-ricerca/" target="_blank" class="list-item">
                 <div class="it-right-zone">
-                  <span class="text"
-                    >Pagina "Risultato Ricerca"
+                  <span class="text">
+                    Pagina "Risultato Ricerca"
                     <em>Esempio di pagina per i risultati di una ricerca a sito</em>
                   </span>
                   <span class="it-multiple"><span class="metadata">Apri in una nuova pagina</span></span>
@@ -139,8 +138,8 @@ title: Template Amministrazione
             <li>
               <a href="template-area-personale/" target="_blank" class="list-item">
                 <div class="it-right-zone">
-                  <span class="text"
-                    >Pagina "Area Personale"
+                  <span class="text">
+                    Pagina "Area Personale"
                     <em>Esempio di pagina per l’Area Personale di un cittadino</em>
                   </span>
                   <span class="it-multiple"><span class="metadata">Apri in una nuova pagina</span></span>
@@ -150,8 +149,8 @@ title: Template Amministrazione
             <li>
               <a href="template-area-personale-dettaglio-pratica/" target="_blank" class="list-item">
                 <div class="it-right-zone">
-                  <span class="text"
-                    >Pagina "Area Personale - Dettaglio Pratica"
+                  <span class="text">
+                    Pagina "Area Personale - Dettaglio Pratica"
                     <em>Esempio di pagina per il dettaglio dello stato di una pratica</em>
                   </span>
                   <span class="it-multiple"><span class="metadata">Apri in una nuova pagina</span></span>

--- a/docs/esempi/comuni/template-amministrazione.html
+++ b/docs/esempi/comuni/template-amministrazione.html
@@ -366,15 +366,21 @@ title: Template Amministrazione
         </div>
         <div class="row">
           <div class="col text-center">
-            <a href="#"
-              ><span class="chip chip-simple chip-primary"><span class="chip-label">Cultura</span></span></a
-            >
-            <a href="#"
-              ><span class="chip chip-simple chip-primary"><span class="chip-label">Muoversi</span></span></a
-            >
-            <a href="#"
-              ><span class="chip chip-simple chip-primary"><span class="chip-label">Argomento di esempio</span></span></a
-            >
+            <a href="#">
+              <span class="chip chip-simple chip-primary">
+                <span class="chip-label">Cultura</span>
+              </span>
+            </a>
+            <a href="#">
+              <span class="chip chip-simple chip-primary">
+                <span class="chip-label">Muoversi</span>
+              </span>
+            </a>
+            <a href="#">
+              <span class="chip chip-simple chip-primary">
+                <span class="chip-label">Argomento di esempio</span>
+              </span>
+            </a>
           </div>
         </div>
       </div>

--- a/docs/esempi/comuni/template-amministrazione.html
+++ b/docs/esempi/comuni/template-amministrazione.html
@@ -101,9 +101,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <span>Luoghi</span>
                 </div>
                 <div class="card-body">
@@ -111,9 +109,7 @@ title: Template Amministrazione
                   <p class="card-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed.</p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -126,9 +122,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-user"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-user"></use></svg>
                   <span>Funzionari amministrativi</span>
                 </div>
                 <div class="card-body">
@@ -138,9 +132,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -153,9 +145,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <span>Uffici</span>
                 </div>
                 <div class="card-body">
@@ -165,9 +155,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -180,9 +168,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <span>Luoghi</span>
                 </div>
                 <div class="card-body">
@@ -190,9 +176,7 @@ title: Template Amministrazione
                   <p class="card-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed.</p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -205,9 +189,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-user"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-user"></use></svg>
                   <span>Politici</span>
                 </div>
                 <div class="card-body">
@@ -217,9 +199,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -232,9 +212,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <span>Luoghi</span>
                 </div>
                 <div class="card-body">
@@ -244,9 +222,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>

--- a/docs/esempi/comuni/template-area-personale-dettaglio-pratica.html
+++ b/docs/esempi/comuni/template-area-personale-dettaglio-pratica.html
@@ -38,29 +38,29 @@ title: Template Area Personale - Dettaglio Pratica
             <div class="nav-tabs-hidescroll mt-4 mt-md-5">
               <ul class="nav nav-tabs auto no-border no-background" id="myTab" role="tablist">
                 <li class="nav-item">
-                  <a class="nav-link text-primary active" id="tab1-tab" data-bs-toggle="tab" href="#" role="tab" aria-controls="tab1" aria-selected="true"
-                    >Le mie pratiche</a
-                  >
+                  <a class="nav-link text-primary active" id="tab1-tab" data-bs-toggle="tab" href="#" role="tab" aria-controls="tab1" aria-selected="true">
+                    Le mie pratiche
+                  </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link text-primary" id="tab2-tab" data-bs-toggle="tab" href="#" role="tab" aria-controls="tab2" aria-selected="false"
-                    >Pagamenti</a
-                  >
+                  <a class="nav-link text-primary" id="tab2-tab" data-bs-toggle="tab" href="#" role="tab" aria-controls="tab2" aria-selected="false">
+                    Pagamenti
+                  </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link text-primary" id="tab3-tab" data-bs-toggle="tab" href="#" role="tab" aria-controls="tab3" aria-selected="false"
-                    >Documenti</a
-                  >
+                  <a class="nav-link text-primary" id="tab3-tab" data-bs-toggle="tab" href="#" role="tab" aria-controls="tab3" aria-selected="false">
+                    Documenti
+                  </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link text-primary" id="tab4-tab" data-bs-toggle="tab" href="#" role="tab" aria-controls="tab4" aria-selected="false"
-                    >Messaggi</a
-                  >
+                  <a class="nav-link text-primary" id="tab4-tab" data-bs-toggle="tab" href="#" role="tab" aria-controls="tab4" aria-selected="false">
+                    Messaggi
+                  </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link text-primary" id="tab5-tab" data-bs-toggle="tab" href="#" role="tab" aria-controls="tab5" aria-selected="false"
-                    >Scadenze</a
-                  >
+                  <a class="nav-link text-primary" id="tab5-tab" data-bs-toggle="tab" href="#" role="tab" aria-controls="tab5" aria-selected="false">
+                    Scadenze
+                  </a>
                 </li>
               </ul>
             </div>

--- a/docs/esempi/comuni/template-area-personale-dettaglio-pratica.html
+++ b/docs/esempi/comuni/template-area-personale-dettaglio-pratica.html
@@ -197,9 +197,7 @@ title: Template Area Personale - Dettaglio Pratica
               </div>
               <div class="callout mt-5">
                 <div class="callout-title">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use></svg>
                 </div>
                 <h4>Ulteriori informazioni</h4>
                 <p>

--- a/docs/esempi/comuni/template-area-personale.html
+++ b/docs/esempi/comuni/template-area-personale.html
@@ -38,29 +38,29 @@ title: Template Area Personale
             <div class="nav-tabs-hidescroll mt-4 mt-md-5">
               <ul class="nav nav-tabs auto no-border no-background" id="myTab" role="tablist">
                 <li class="nav-item">
-                  <a class="nav-link text-primary active" id="tab1-tab" data-bs-toggle="tab" href="#tab1" role="tab" aria-controls="tab1" aria-selected="true"
-                    >Le mie pratiche</a
-                  >
+                  <a class="nav-link text-primary active" id="tab1-tab" data-bs-toggle="tab" href="#tab1" role="tab" aria-controls="tab1" aria-selected="true">
+                    Le mie pratiche
+                  </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link text-primary" id="tab2-tab" data-bs-toggle="tab" href="#tab2" role="tab" aria-controls="tab2" aria-selected="false"
-                    >Pagamenti</a
-                  >
+                  <a class="nav-link text-primary" id="tab2-tab" data-bs-toggle="tab" href="#tab2" role="tab" aria-controls="tab2" aria-selected="false">
+                    Pagamenti
+                  </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link text-primary" id="tab3-tab" data-bs-toggle="tab" href="#tab3" role="tab" aria-controls="tab3" aria-selected="false"
-                    >Documenti</a
-                  >
+                  <a class="nav-link text-primary" id="tab3-tab" data-bs-toggle="tab" href="#tab3" role="tab" aria-controls="tab3" aria-selected="false">
+                    Documenti
+                  </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link text-primary" id="tab4-tab" data-bs-toggle="tab" href="#tab4" role="tab" aria-controls="tab4" aria-selected="false"
-                    >Messaggi</a
-                  >
+                  <a class="nav-link text-primary" id="tab4-tab" data-bs-toggle="tab" href="#tab4" role="tab" aria-controls="tab4" aria-selected="false">
+                    Messaggi
+                  </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link text-primary" id="tab5-tab" data-bs-toggle="tab" href="#tab5" role="tab" aria-controls="tab5" aria-selected="false"
-                    >Scadenze</a
-                  >
+                  <a class="nav-link text-primary" id="tab5-tab" data-bs-toggle="tab" href="#tab5" role="tab" aria-controls="tab5" aria-selected="false">
+                    Scadenze
+                  </a>
                 </li>
               </ul>
             </div>

--- a/docs/esempi/comuni/template-argomenti-argomento.html
+++ b/docs/esempi/comuni/template-argomenti-argomento.html
@@ -92,9 +92,7 @@ title: Template Argomento
                 </div>
                 <div class="card-body p-4">
                   <div class="category-top">
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use></svg>
                     <a class="category" href="#">Notizie</a>
                     <span class="data">18 mag {{'now' | date: "%Y"}}</span>
                   </div>
@@ -115,9 +113,7 @@ title: Template Argomento
               <div class="card no-after rounded shadow">
                 <div class="card-body">
                   <div class="category-top">
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use></svg>
                     <a class="category" href="#">Notizie</a>
                     <span class="data">18 mag {{'now' | date: "%Y"}}</span>
                   </div>
@@ -131,9 +127,7 @@ title: Template Argomento
               <div class="card no-after rounded shadow">
                 <div class="card-body">
                   <div class="category-top">
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use></svg>
                     <a class="category" href="#">Notizie</a>
                     <span class="data">18 mag {{'now' | date: "%Y"}}</span>
                   </div>
@@ -160,9 +154,7 @@ title: Template Argomento
               <div class="card no-after rounded shadow">
                 <div class="card-body">
                   <div class="category-top">
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-note"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-note"></use></svg>
                     <a class="category" href="#">Bandi</a>
                   </div>
                   <h5 class="card-title">Come partecipare ad un bando</h5>
@@ -193,9 +185,7 @@ title: Template Argomento
             <div class="card card-teaser card-teaser-image card-flex rounded shadow">
               <div class="card-body p-4">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Giunta e consiglio</a>
                 </div>
                 <h5 class="card-title">Gabriele Bianchi</h5>
@@ -208,9 +198,7 @@ title: Template Argomento
             <div class="card card-teaser rounded shadow">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Aree di competenza</a>
                 </div>
                 <h5 class="card-title">Area edilizia e trasporto pubblico locale</h5>
@@ -220,9 +208,7 @@ title: Template Argomento
             <div class="card card-teaser rounded shadow">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Aree di competenza</a>
                 </div>
                 <h5 class="card-title">Area lavori pubblici</h5>
@@ -246,9 +232,7 @@ title: Template Argomento
             <div class="card card-teaser rounded shadow">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Sostegno</a>
                 </div>
                 <h5 class="card-title">Mappa dei cantieri</h5>
@@ -258,9 +242,7 @@ title: Template Argomento
             <div class="card card-teaser rounded shadow">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Segnalazioni</a>
                 </div>
                 <h5 class="card-title">Richiesta risarcimento danni al Comune</h5>
@@ -299,9 +281,7 @@ title: Template Argomento
                 </div>
                 <div class="card-body p-4">
                   <div class="category-top">
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use></svg>
                     <a class="category" href="#">Notizie</a>
                     <span class="data">18 mag {{'now' | date: "%Y"}}</span>
                   </div>
@@ -333,9 +313,7 @@ title: Template Argomento
                 </div>
                 <div class="card-body p-4">
                   <div class="category-top">
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use></svg>
                     <a class="category" href="#">Eventi</a>
                     <span class="data">dal 2 al 3 mag {{'now' | date: "%Y"}}</span>
                   </div>
@@ -356,9 +334,7 @@ title: Template Argomento
               <div class="card no-after rounded shadow">
                 <div class="card-body">
                   <div class="category-top">
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-note"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-note"></use></svg>
                     <a class="category" href="#">Notizie</a>
                     <span class="data">18 mag {{'now' | date: "%Y"}}</span>
                   </div>
@@ -372,9 +348,7 @@ title: Template Argomento
               <div class="card no-after rounded shadow">
                 <div class="card-body">
                   <div class="category-top">
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-note"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-note"></use></svg>
                     <a class="category" href="#">Comunicati stampa</a>
                     <span class="data">18 mag {{'now' | date: "%Y"}}</span>
                   </div>
@@ -439,9 +413,7 @@ title: Template Argomento
             <div class="card card-teaser rounded shadow">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-note"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-note"></use></svg>
                   <a class="category" href="#">Bandi</a>
                 </div>
                 <h5 class="card-title">Bandi edilizia e strade</h5>
@@ -451,9 +423,7 @@ title: Template Argomento
             <div class="card card-teaser rounded shadow">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-note"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-note"></use></svg>
                   <a class="category" href="#">Bandi</a>
                 </div>
                 <h5 class="card-title">Bando verde pubblico</h5>
@@ -463,9 +433,7 @@ title: Template Argomento
             <div class="card card-teaser rounded shadow">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-note"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-note"></use></svg>
                   <a class="category" href="#">Progetti e attività</a>
                 </div>
                 <h5 class="card-title">Piano lavori 2019</h5>

--- a/docs/esempi/comuni/template-argomenti.html
+++ b/docs/esempi/comuni/template-argomenti.html
@@ -257,9 +257,7 @@ title: Template Argomenti
           <div class="col">
             <div class="card-wrapper card-teaser-wrapper card-teaser-wrapper-equal card-teaser-block-3">
               <div class="card card-teaser rounded shadow align-items-center">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use></svg>
                 <div class="card-body">
                   <h5 class="card-title mb-0">
                     <a href="#">Agevolazioni per la casa</a>
@@ -267,9 +265,7 @@ title: Template Argomenti
                 </div>
               </div>
               <div class="card card-teaser rounded shadow align-items-center">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use></svg>
                 <div class="card-body">
                   <h5 class="card-title mb-0">
                     <a href="#">Animali</a>
@@ -277,9 +273,7 @@ title: Template Argomenti
                 </div>
               </div>
               <div class="card card-teaser rounded shadow align-items-center">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use></svg>
                 <div class="card-body">
                   <h5 class="card-title mb-0">
                     <a href="#">Anziani</a>
@@ -287,9 +281,7 @@ title: Template Argomenti
                 </div>
               </div>
               <div class="card card-teaser rounded shadow align-items-center">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use></svg>
                 <div class="card-body">
                   <h5 class="card-title mb-0">
                     <a href="#">Assistenza e inclusione</a>
@@ -297,9 +289,7 @@ title: Template Argomenti
                 </div>
               </div>
               <div class="card card-teaser rounded shadow align-items-center">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use></svg>
                 <div class="card-body">
                   <h5 class="card-title mb-0">
                     <a href="#">Associazioni</a>
@@ -307,9 +297,7 @@ title: Template Argomenti
                 </div>
               </div>
               <div class="card card-teaser rounded shadow align-items-center">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use></svg>
                 <div class="card-body">
                   <h5 class="card-title mb-0">
                     <a href="#">Bambini e ragazzi</a>
@@ -317,9 +305,7 @@ title: Template Argomenti
                 </div>
               </div>
               <div class="card card-teaser rounded shadow align-items-center">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use></svg>
                 <div class="card-body">
                   <h5 class="card-title mb-0">
                     <a href="#">Cantieri e progetti</a>
@@ -327,9 +313,7 @@ title: Template Argomenti
                 </div>
               </div>
               <div class="card card-teaser rounded shadow align-items-center">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use></svg>
                 <div class="card-body">
                   <h5 class="card-title mb-0">
                     <a href="#">Comune</a>
@@ -337,9 +321,7 @@ title: Template Argomenti
                 </div>
               </div>
               <div class="card card-teaser rounded shadow align-items-center">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-help-circle"></use></svg>
                 <div class="card-body">
                   <h5 class="card-title mb-0">
                     <a href="#">Comunicare con il Comune</a>

--- a/docs/esempi/comuni/template-documenti.html
+++ b/docs/esempi/comuni/template-documenti.html
@@ -275,15 +275,21 @@ title: Template Amministrazione
         </div>
         <div class="row">
           <div class="col text-center">
-            <a href="#"
-              ><span class="chip chip-simple chip-primary"><span class="chip-label">Cultura</span></span></a
-            >
-            <a href="#"
-              ><span class="chip chip-simple chip-primary"><span class="chip-label">Muoversi</span></span></a
-            >
-            <a href="#"
-              ><span class="chip chip-simple chip-primary"><span class="chip-label">Argomento di esempio</span></span></a
-            >
+            <a href="#">
+              <span class="chip chip-simple chip-primary">
+                <span class="chip-label">Cultura</span>
+              </span>
+            </a>
+            <a href="#">
+              <span class="chip chip-simple chip-primary">
+                <span class="chip-label">Muoversi</span>
+              </span>
+            </a>
+            <a href="#">
+              <span class="chip chip-simple chip-primary">
+                <span class="chip-label">Argomento di esempio</span>
+              </span>
+              </a>
           </div>
         </div>
       </div>

--- a/docs/esempi/comuni/template-documenti.html
+++ b/docs/esempi/comuni/template-documenti.html
@@ -86,9 +86,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-files"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-files"></use></svg>
                   <span>Atti</span>
                 </div>
                 <div class="card-body">
@@ -96,9 +94,7 @@ title: Template Amministrazione
                   <p class="card-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed.</p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -111,9 +107,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-files"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-files"></use></svg>
                   <span>Atti</span>
                 </div>
                 <div class="card-body">
@@ -123,9 +117,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -138,9 +130,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-files"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-files"></use></svg>
                   <span>Atti</span>
                 </div>
                 <div class="card-body">
@@ -150,9 +140,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -165,9 +153,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-file"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-file"></use></svg>
                   <span>Comunicazione</span>
                 </div>
                 <div class="card-body">
@@ -175,9 +161,7 @@ title: Template Amministrazione
                   <p class="card-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed.</p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -190,9 +174,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-presentation"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-presentation"></use></svg>
                   <span>Dati</span>
                 </div>
                 <div class="card-body">
@@ -202,9 +184,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -217,9 +197,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-files"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-files"></use></svg>
                   <span>Atti</span>
                 </div>
                 <div class="card-body">
@@ -229,9 +207,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -262,9 +238,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -282,9 +256,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>

--- a/docs/esempi/comuni/template-homepage.html
+++ b/docs/esempi/comuni/template-homepage.html
@@ -16,9 +16,7 @@ title: Template Home Page
           <div class="card">
             <div class="card-body pb-5">
               <div class="category-top">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use></svg>
                 <a class="category" href="#">Notizie</a>
                 <span class="data">18 mag {{'now' | date: "%Y"}}</span>
               </div>
@@ -50,9 +48,7 @@ title: Template Home Page
               <div class="card-image-wrapper with-read-more pb-5">
                 <div class="card-body p-4">
                   <div class="category-top">
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                     <a class="category" href="#">Giunta e consiglio</a>
                   </div>
                   <p class="card-title fw-semibold">Mario Rossi</p>
@@ -65,17 +61,13 @@ title: Template Home Page
 
               <a class="read-more ps-4" href="{{ site.baseurl }}/docs/esempi/comuni/template-amministrazione/">
                 <span class="text">Tutta l'amministrazione</span>
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
               </a>
             </div>
             <div class="card card-teaser no-after rounded shadow">
               <div class="card-body pb-5">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Pagamenti</a>
                 </div>
                 <p class="card-title fw-semibold">TARI - Tassa dei rifiuti</p>
@@ -83,17 +75,13 @@ title: Template Home Page
               </div>
               <a class="read-more" href="#">
                 <span class="text">Tutti i servizi</span>
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
               </a>
             </div>
             <div class="card card-teaser no-after rounded shadow">
               <div class="card-body pb-5">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Bandi</a>
                 </div>
                 <p class="card-title fw-semibold">Come partecipare ad un bando</p>
@@ -101,9 +89,7 @@ title: Template Home Page
               </div>
               <a class="read-more" href="{{ site.baseurl }}/docs/esempi/comuni/template-documenti/">
                 <span class="text">Tutti i documenti</span>
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
               </a>
             </div>
           </div>
@@ -114,21 +100,15 @@ title: Template Home Page
             <div>
               <button type="button" class="mt-1 btn btn-secondary btn-sm">Tutto</button>
               <button type="button" class="mt-1 btn btn-outline-secondary btn-sm btn-icon">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                 <span>Consigli comunali</span>
               </button>
               <button type="button" class="mt-1 btn btn-outline-secondary btn-sm btn-icon">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use></svg>
                 <span>Eventi</span>
               </button>
               <button type="button" class="mt-1 btn btn-outline-secondary btn-sm btn-icon">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-settings"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-settings"></use></svg>
                 Scadenze
               </button>
             </div>
@@ -266,9 +246,7 @@ title: Template Home Page
             <div class="card card-teaser no-after rounded shadow">
               <div class="card-body pb-5">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use></svg>
                 </div>
                 <h3 class="card-title">Cantieri in città</h3>
                 <p class="card-text">
@@ -289,17 +267,13 @@ title: Template Home Page
               </div>
               <a class="read-more" href="#">
                 <span class="text">Esplora argomento</span>
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
               </a>
             </div>
             <div class="card card-teaser no-after rounded shadow">
               <div class="card-body pb-5">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clock"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clock"></use></svg>
                 </div>
                 <h3 class="card-title">Estate in città</h3>
                 <p class="card-text">
@@ -345,18 +319,14 @@ title: Template Home Page
               <a class="read-more" href="#">
                 <span class="list-item-title-icon-wrapper">
                   <span class="text">Esplora argomento</span>
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </span>
               </a>
             </div>
             <div class="card card-teaser no-after rounded shadow">
               <div class="card-body pb-5">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-camera"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-camera"></use></svg>
                 </div>
                 <h3 class="card-title">Sport</h3>
                 <p class="card-text">
@@ -394,9 +364,7 @@ title: Template Home Page
               </div>
               <a class="read-more" href="#">
                 <span class="text">Esplora argomento</span>
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
               </a>
             </div>
           </div>

--- a/docs/esempi/comuni/template-homepage.html
+++ b/docs/esempi/comuni/template-homepage.html
@@ -29,9 +29,7 @@ title: Template Home Page
               </div>
               <a class="read-more pb-3" href="{{ site.baseurl }}/docs/esempi/comuni/template-novita/">
                 <span class="text">Tutte le novità</span>
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg##it-arrow-right"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
               </a>
             </div>
           </div>

--- a/docs/esempi/comuni/template-novita-evento.html
+++ b/docs/esempi/comuni/template-novita-evento.html
@@ -42,20 +42,20 @@ title: Template Evento Comunale
         {% include esempi/comuni/condividi.html %}
         <div class="mt-4 mb-4">
           <h6><small>Argomenti</small></h6>
-          <a href="#"
-            ><div class="chip chip-simple chip-primary">
+          <a href="#">
+            <div class="chip chip-simple chip-primary">
               <span class="chip-label">Cultura</span>
-            </div></a>
-          <a href="#"
-            ><div class="chip chip-simple chip-primary">
+            </div>
+          </a>
+          <a href="#">
+            <div class="chip chip-simple chip-primary">
               <span class="chip-label">Vivere la città</span>
-            </div></a>
+            </div>
+          </a>
         </div>
         <div class="mt-5">
           <a href="#" class="btn btn-outline-primary btn-icon">
-            <svg class="icon icon-primary">
-              <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use>
-            </svg>
+            <svg class="icon icon-primary"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use></svg>
             <span>Vai al calendario eventi</span>
           </a>
         </div>
@@ -97,51 +97,35 @@ title: Template Evento Comunale
                 <svg class="icon icon-sm icon-primary align-top">
                   <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-chevron-left"></use>
                 </svg>
-                <span>Torna indietro</span></a
-              >
+                <span>Torna indietro</span>
+              </a>
               <div class="menu-wrapper">
                 <div class="link-list-wrapper menu-link-list">
                   <h3 class="no_toc">Indice della pagina</h3>
                   <ul class="link-list">
                     <li class="nav-item active">
-                      <a class="nav-link active" href="#cos-e"
-                        ><span>Cos'è</span></a
-                      >
+                      <a class="nav-link active" href="#cos-e"><span>Cos'è</span></a>
                     </li>
                     <li class="nav-item">
-                      <a class="nav-link" href="#luogo"
-                        ><span>Luogo</span></a
-                      >
+                      <a class="nav-link" href="#luogo"><span>Luogo</span></a>
                     </li>
                     <li class="nav-item">
-                      <a class="nav-link" href="#date-e-orari"
-                        ><span>Date e orari</span></a
-                      >
+                      <a class="nav-link" href="#date-e-orari"><span>Date e orari</span></a>
                     </li>
                     <li class="nav-item">
-                      <a class="nav-link" href="#costi"
-                        ><span>Costi</span></a
-                      >
+                      <a class="nav-link" href="#costi"><span>Costi</span></a>
                     </li>
                     <li class="nav-item">
-                      <a class="nav-link" href="#documenti"
-                        ><span>Documenti</span></a
-                      >
+                      <a class="nav-link" href="#documenti"><span>Documenti</span></a>
                     </li>
                     <li class="nav-item">
-                      <a class="nav-link" href="#contatti"
-                        ><span>Contatti</span></a
-                      >
+                      <a class="nav-link" href="#contatti"><span>Contatti</span></a>
                     </li>
                     <li class="nav-item">
-                      <a class="nav-link" href="#appuntamenti"
-                        ><span>Appuntamenti</span></a
-                      >
+                      <a class="nav-link" href="#appuntamenti"><span>Appuntamenti</span></a>
                     </li>
                     <li class="nav-item">
-                      <a class="nav-link" href="#ulteriori-informazioni"
-                        ><span>Ulteriori informazioni</span></a
-                      >
+                      <a class="nav-link" href="#ulteriori-informazioni"><span>Ulteriori informazioni</span></a>
                     </li>
                   </ul>
                 </div>

--- a/docs/esempi/comuni/template-novita-evento.html
+++ b/docs/esempi/comuni/template-novita-evento.html
@@ -247,9 +247,7 @@ title: Template Evento Comunale
           <h4>Luogo</h4>
           <div class="card-wrapper card-teaser-wrapper">
             <div class="card card-teaser shadow mt-3 rounded">
-              <svg class="icon">
-                <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pin"></use>
-              </svg>
+              <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pin"></use></svg>
               <div class="card-body">
                 <h5 class="card-title">
                   Cagliari
@@ -353,9 +351,7 @@ title: Template Evento Comunale
         <article id="documenti" class="it-page-section anchor-offset mt-5">
           <h4>Documenti</h4>
           <div class="card card-teaser shadow mt-3 rounded">
-            <svg class="icon">
-              <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clip"></use>
-            </svg>
+            <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clip"></use></svg>
             <div class="card-body">
               <h5 class="card-title">
                 <a href="#">Locandina Sant'Efisio 2019</a>
@@ -366,9 +362,7 @@ title: Template Evento Comunale
         <article id="contatti" class="it-page-section anchor-offset mt-5">
           <h4>Contatti</h4>
           <div class="card card-teaser shadow mt-3 rounded">
-            <svg class="icon">
-              <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-telephone"></use>
-            </svg>
+            <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-telephone"></use></svg>
             <div class="card-body">
               <h5 class="card-title">
                 Arciconfraternita del Gonfalone sotto l’invocazione di Sant'Efisio martire
@@ -383,9 +377,7 @@ title: Template Evento Comunale
           </div>
           <h5 class="mt-4">Con il supporto di:</h5>
           <div class="card card-teaser shadow mt-3 rounded">
-            <svg class="icon">
-              <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-            </svg>
+            <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
             <div class="card-body">
               <h5 class="card-title">
                 Ufficio delle Attività Produttive
@@ -595,9 +587,7 @@ title: Template Evento Comunale
           <div class="mt-5">
             <div class="callout">
               <div class="callout-title">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use></svg>
               </div>
               <p>Per ulteriori informazioni contattare <a href="">santefisio@comune.cagliari.it</a></p>
               <h6><a href="#">Ufficio Sant'Elfisio</a></h6>

--- a/docs/esempi/comuni/template-novita-evento.html
+++ b/docs/esempi/comuni/template-novita-evento.html
@@ -412,9 +412,7 @@ title: Template Evento Comunale
                     <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
                     <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span>
-                    <svg class="icon">
-                      <use href="/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg></a>
+                    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg></a>
                 </div>
               </div>
             </div>
@@ -437,9 +435,7 @@ title: Template Evento Comunale
                     <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
                     <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span>
-                    <svg class="icon">
-                      <use href="/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg></a>
+                    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg></a>
                 </div>
               </div>
             </div>
@@ -462,9 +458,7 @@ title: Template Evento Comunale
                     <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
                     <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit…</span>
-                    <svg class="icon">
-                      <use href="/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg></a>
+                    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg></a>
                 </div>
               </div>
             </div>

--- a/docs/esempi/comuni/template-novita-notizia.html
+++ b/docs/esempi/comuni/template-novita-notizia.html
@@ -43,16 +43,16 @@ title: Template Pagina Notizia
         {% include esempi/comuni/condividi.html %}
         <div class="mt-4 mb-4">
           <h6><small>Argomenti</small></h6>
-          <a href="#"
-            ><div class="chip chip-simple chip-primary">
+          <a href="#">
+            <div class="chip chip-simple chip-primary">
               <span class="chip-label">Cultura</span>
-            </div></a
-          >
-          <a href="#"
-            ><div class="chip chip-simple chip-primary">
+            </div>
+            </a>
+          <a href="#">
+            <div class="chip chip-simple chip-primary">
               <span class="chip-label">Muoversi</span>
-            </div></a
-          >
+            </div>
+          </a>
         </div>
       </div>
     </div>
@@ -163,16 +163,16 @@ title: Template Pagina Notizia
             </div>
             <div class="col-12 col-sm-4">
               <h6><small>Persone</small></h6>
-              <a href="#"
-                ><div class="chip chip-simple chip-primary">
+              <a href="#">
+                <div class="chip chip-simple chip-primary">
                   <span class="chip-label">Mario Rossi</span>
-                </div></a
-              >
-              <a href="#"
-                ><div class="chip chip-simple chip-primary">
+                </div>
+              </a>
+              <a href="#">
+                <div class="chip chip-simple chip-primary">
                   <span class="chip-label">Alessandro Bianchi</span>
-                </div></a
-              >
+                </div>
+              </a>
             </div>
           </div>
         </article>

--- a/docs/esempi/comuni/template-novita-notizia.html
+++ b/docs/esempi/comuni/template-novita-notizia.html
@@ -126,9 +126,7 @@ title: Template Pagina Notizia
           <h4>Documenti</h4>
           <div class="card-wrapper card-teaser-wrapper card-teaser-wrapper-equal">
             <div class="card card-teaser shadow p-4 mt-3 rounded border">
-              <svg class="icon">
-                <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clip"></use>
-              </svg>
+              <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clip"></use></svg>
               <div class="card-body">
                 <h5 class="card-title">
                   <a href="#">Lo speciale di National Geographic sulle regate in Sardegna</a>
@@ -136,9 +134,7 @@ title: Template Pagina Notizia
               </div>
             </div>
             <div class="card card-teaser shadow p-4 mt-3 rounded border">
-              <svg class="icon">
-                <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clip"></use>
-              </svg>
+              <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clip"></use></svg>
               <div class="card-body">
                 <h5 class="card-title">
                   <a href="#">Le rotte del mare: porti e approdi sulle coste dell'Isola</a>

--- a/docs/esempi/comuni/template-novita.html
+++ b/docs/esempi/comuni/template-novita.html
@@ -110,9 +110,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="{{ site.baseurl }}/docs/esempi/comuni/template-novita-notizia/">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -125,9 +123,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-user"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-user"></use></svg>
                   <span>Notizie</span>
                 </div>
                 <div class="card-body">
@@ -137,9 +133,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="{{ site.baseurl }}/docs/esempi/comuni/template-novita-notizia/">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -202,9 +196,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -222,9 +214,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -242,9 +232,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>

--- a/docs/esempi/comuni/template-novita.html
+++ b/docs/esempi/comuni/template-novita.html
@@ -162,11 +162,10 @@ title: Template Amministrazione
                 <div class="card-body p-4">
                   <h5 class="card-title">Sagra di paese</h5>
                   <p class="card-text">Una breve descrizione della sagra e dei suoi momenti salienti.</p>
-                  <a class="read-more" href="#"
-                    ><span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg
-                  ></a>
+                  <a class="read-more" href="#">
+                    <span class="text">Leggi di più</span>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                  </a>
                 </div>
               </div>
             </article>
@@ -251,15 +250,21 @@ title: Template Amministrazione
         </div>
         <div class="row">
           <div class="col text-center">
-            <a href="#"
-              ><span class="chip chip-simple chip-primary"><span class="chip-label">Cultura</span></span></a
-            >
-            <a href="#"
-              ><span class="chip chip-simple chip-primary"><span class="chip-label">Muoversi</span></span></a
-            >
-            <a href="#"
-              ><span class="chip chip-simple chip-primary"><span class="chip-label">Argomento di esempio</span></span></a
-            >
+            <a href="#">
+              <span class="chip chip-simple chip-primary">
+                <span class="chip-label">Cultura</span>
+              </span>
+              </a>
+            <a href="#">
+              <span class="chip chip-simple chip-primary">
+                <span class="chip-label">Muoversi</span>
+              </span>
+              </a>
+            <a href="#">
+              <span class="chip chip-simple chip-primary">
+                <span class="chip-label">Argomento di esempio</span>
+              </span>
+              </a>
           </div>
         </div>
       </div>

--- a/docs/esempi/comuni/template-risultato-ricerca.html
+++ b/docs/esempi/comuni/template-risultato-ricerca.html
@@ -134,9 +134,9 @@ title: Template Singolo Argomento
               </div>
             </div>
             <div class="mt-4">
-              <a class="fw-bold" data-bs-toggle="collapse" href="#collapseList" role="button" aria-expanded="false" aria-controls="collapseList"
-                >Mostra tutto</a
-              >
+              <a class="fw-bold" data-bs-toggle="collapse" href="#collapseList" role="button" aria-expanded="false" aria-controls="collapseList">
+                Mostra tutto
+              </a>
             </div>
           </div>
         </div>

--- a/docs/esempi/comuni/template-risultato-ricerca.html
+++ b/docs/esempi/comuni/template-risultato-ricerca.html
@@ -160,9 +160,7 @@ title: Template Singolo Argomento
             <div class="card card-teaser">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Servizi</a>
                 </div>
                 <h4 class="card-title">
@@ -178,9 +176,7 @@ title: Template Singolo Argomento
             <div class="card card-teaser">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Servizi</a>
                 </div>
                 <h4 class="card-title">
@@ -196,9 +192,7 @@ title: Template Singolo Argomento
             <div class="card card-teaser">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Servizi</a>
                 </div>
                 <h4 class="card-title">
@@ -214,9 +208,7 @@ title: Template Singolo Argomento
             <div class="card card-teaser">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Servizi</a>
                 </div>
                 <h4 class="card-title">
@@ -232,9 +224,7 @@ title: Template Singolo Argomento
             <div class="card card-teaser">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Servizi</a>
                 </div>
                 <h4 class="card-title">
@@ -250,9 +240,7 @@ title: Template Singolo Argomento
             <div class="card card-teaser">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Servizi</a>
                 </div>
                 <h4 class="card-title">
@@ -268,9 +256,7 @@ title: Template Singolo Argomento
             <div class="card card-teaser">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Servizi</a>
                 </div>
                 <h4 class="card-title">
@@ -286,9 +272,7 @@ title: Template Singolo Argomento
             <div class="card card-teaser">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Servizi</a>
                 </div>
                 <h4 class="card-title">
@@ -304,9 +288,7 @@ title: Template Singolo Argomento
             <div class="card card-teaser">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Servizi</a>
                 </div>
                 <h4 class="card-title">
@@ -322,9 +304,7 @@ title: Template Singolo Argomento
             <div class="card card-teaser">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Servizi</a>
                 </div>
                 <h4 class="card-title">
@@ -340,9 +320,7 @@ title: Template Singolo Argomento
             <div class="card card-teaser">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Servizi</a>
                 </div>
                 <h4 class="card-title">
@@ -358,9 +336,7 @@ title: Template Singolo Argomento
             <div class="card card-teaser">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Servizi</a>
                 </div>
                 <h4 class="card-title">
@@ -376,9 +352,7 @@ title: Template Singolo Argomento
             <div class="card card-teaser">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Servizi</a>
                 </div>
                 <h4 class="card-title">
@@ -394,9 +368,7 @@ title: Template Singolo Argomento
             <div class="card card-teaser">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Servizi</a>
                 </div>
                 <h4 class="card-title">
@@ -412,9 +384,7 @@ title: Template Singolo Argomento
             <div class="card card-teaser">
               <div class="card-body">
                 <div class="category-top">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <a class="category" href="#">Servizi</a>
                 </div>
                 <h4 class="card-title">

--- a/docs/esempi/comuni/template-servizi-servizio.html
+++ b/docs/esempi/comuni/template-servizi-servizio.html
@@ -32,21 +32,21 @@ title: Template Servizio Comunale
         {% include esempi/comuni/condividi.html %}
         <div class="mt-4 mb-4">
           <h6><small>Argomenti</small></h6>
-          <a href="#"
-            ><div class="chip chip-simple chip-primary">
+          <a href="#">
+            <div class="chip chip-simple chip-primary">
               <span class="chip-label">Famiglia</span>
-            </div></a
-          >
-          <a href="#"
-            ><div class="chip chip-simple chip-primary">
+            </div>
+          </a>
+          <a href="#">
+            <div class="chip chip-simple chip-primary">
               <span class="chip-label">Servizi e supporto all'educazione</span>
-            </div></a
-          >
-          <a href="#"
-            ><div class="chip chip-simple chip-primary">
+            </div>
+          </a>
+          <a href="#">
+            <div class="chip chip-simple chip-primary">
               <span class="chip-label">Bambini e ragazzi</span>
-            </div></a
-          >
+            </div>
+          </a>
         </div>
       </div>
     </div>
@@ -178,9 +178,7 @@ title: Template Servizio Comunale
             oppure al seguente ufficio:
           </p>
           <div class="card card-teaser shadow p-4 my-5 rounded">
-            <svg class="icon">
-              <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-            </svg>
+            <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
             <div class="card-body">
               <h5 class="card-title">Ufficio Asili Nido</h5>
               <div class="card-text">
@@ -198,9 +196,7 @@ title: Template Servizio Comunale
           <h4>Cosa serve</h4>
           <div class="callout">
             <div class="callout-title">
-              <svg class="icon">
-                <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use>
-              </svg>
+              <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use></svg>
             </div>
             <ul>
               <li>
@@ -285,9 +281,7 @@ title: Template Servizio Comunale
           <h4>Documenti</h4>
           <div class="card-wrapper card-teaser-wrapper card-teaser-wrapper-equal card-teaser-block-2">
             <div class="card card-teaser shadow p-4">
-              <svg class="icon">
-                <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clip"></use>
-              </svg>
+              <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clip"></use></svg>
               <div class="card-body">
                 <h5 class="card-title">
                   <a href="#">Avviso pubblico di iscrizione - Anno educativo 2022/2023</a>
@@ -298,9 +292,7 @@ title: Template Servizio Comunale
               </div>
             </div>
             <div class="card card-teaser shadow p-4">
-              <svg class="icon">
-                <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clip"></use>
-              </svg>
+              <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clip"></use></svg>
               <div class="card-body">
                 <h5 class="card-title">
                   <a href="#">Guida informativa - Anno 2022/2023 </a>
@@ -311,9 +303,7 @@ title: Template Servizio Comunale
               </div>
             </div>
             <div class="card card-teaser shadow p-4">
-              <svg class="icon">
-                <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clip"></use>
-              </svg>
+              <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-clip"></use></svg>
               <div class="card-body">
                 <h5 class="card-title">
                   <a href="#">Rette asili nido </a>
@@ -329,8 +319,7 @@ title: Template Servizio Comunale
           <h4>Ulteriori informazioni</h4>
           <div class="callout">
             <div class="callout-title">
-              <svg class="icon">
-                <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use>
+              <svg class="icon">                <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use>
               </svg>
             </div>
             <p>La pubblicazione dell'avviso riguardante le nuove iscrizioni per l'anno scolastico 2023/2024 è prevista per il mese di aprile 2022.</p>

--- a/docs/esempi/comuni/template-servizi.html
+++ b/docs/esempi/comuni/template-servizi.html
@@ -11,7 +11,8 @@ title: Template Amministrazione
       <div class="col px-lg-4">
         <nav aria-label="Percorso di navigazione" class="breadcrumb-container">
           <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{{ site.baseurl }}/docs/esempi/comuni/template-homepage/">Home</a><span class="separator">/</span></li>
+            <li class="breadcrumb-item"><a href="{{ site.baseurl }}/docs/esempi/comuni/template-homepage/">Home</a><span
+                class="separator">/</span></li>
             <li aria-current="page" class="breadcrumb-item active">Servizi</li>
           </ol>
         </nav>
@@ -23,14 +24,18 @@ title: Template Amministrazione
       <div class="col-lg-7 px-lg-4 py-lg-2">
         <h1>Servizi</h1>
         <p>
-          Donec in consequat nunc. Duis semper fermentum lacus, ac condimentum justo auctor a. Nam erat erat, porta vel pharetra in, ullamcorper vel turpis.
+          Donec in consequat nunc. Duis semper fermentum lacus, ac condimentum justo auctor a. Nam erat erat, porta vel
+          pharetra in, ullamcorper vel turpis.
         </p>
         <div class="form-group mt-5">
           <form>
             <input id="ricerca-amministrazione" type="search" />
-            <label for="ricerca-amministrazione">Cerca contenuti in "Servizi" <span class="visually-hidden">(invia per lanciare la ricerca)</span></label>
+            <label for="ricerca-amministrazione">Cerca contenuti in "Servizi" <span class="visually-hidden">(invia per
+                lanciare la ricerca)</span></label>
             <span aria-hidden="true" class="autocomplete-icon">
-              <svg class="icon icon-sm"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-search"></use></svg>
+              <svg class="icon icon-sm">
+                <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-search"></use>
+              </svg>
             </span>
             <button type="submit" tabindex="-1" class="visually-hidden">Invia</button>
           </form>
@@ -40,7 +45,9 @@ title: Template Amministrazione
           <div class="chip chip-lg">
             <span class="chip-label">Tutto</span>
             <button>
-              <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
+              <svg class="icon">
+                <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
+              </svg>
               <span class="visually-hidden">Elimina label</span>
             </button>
           </div>
@@ -79,8 +86,11 @@ title: Template Amministrazione
               <a class="list-item" href="#">Catasto e urbanistica</a>
             </li>
             <li>
-              <a class="list-item large medium left-icon" href="#altri-servizi" data-bs-toggle="collapse" aria-expanded="false" aria-controls="altri-servizi">
-                <svg class="icon icon-primary right"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-more-items"></use></svg>
+              <a class="list-item large medium left-icon" href="#altri-servizi" data-bs-toggle="collapse"
+                aria-expanded="false" aria-controls="altri-servizi">
+                <svg class="icon icon-primary right">
+                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-more-items"></use>
+                </svg>
                 <span class="visually-hidden">Apri/chiudi lista altri servizi</span>
               </a>
               <ul class="link-sublist collapse px-0" id="altri-servizi">
@@ -136,17 +146,22 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon"></div>
                 <div class="etichetta">
-                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
+                  <svg class="icon">
+                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
+                  </svg>
                   <span>Scuola e formazione</span>
                 </div>
                 <div class="card-body">
                   <h5 class="card-title">Iscrizione agli asili nido</h5>
                   <p class="card-text">
-                    Come iscrivere i propri figli agli asili nido comunali, strutture convenzionate, sezioni sperimentali e micronido a domicilio.
+                    Come iscrivere i propri figli agli asili nido comunali, strutture convenzionate, sezioni
+                    sperimentali e micronido a domicilio.
                   </p>
                   <a class="read-more" href="{{ site.baseurl }}/docs/esempi/comuni/template-servizi-servizio/">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -159,17 +174,22 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-user"></use></svg>
+                  <svg class="icon">
+                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-user"></use>
+                  </svg>
                   <span>Funzionari amministrativi</span>
                 </div>
                 <div class="card-body">
                   <h5 class="card-title">Lorem ipsum dolor sit amet</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -182,17 +202,23 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
+                  <svg class="icon">
+                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
+                  </svg>
                   <span>Uffici</span>
                 </div>
                 <div class="card-body">
-                  <h5 class="card-title">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</h5>
+                  <h5 class="card-title">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…
+                  </h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -205,15 +231,20 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
+                  <svg class="icon">
+                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
+                  </svg>
                   <span>Luoghi</span>
                 </div>
                 <div class="card-body">
-                  <h5 class="card-title">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</h5>
+                  <h5 class="card-title">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…
+                  </h5>
                   <p class="card-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed.</p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -226,17 +257,22 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-user"></use></svg>
+                  <svg class="icon">
+                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-user"></use>
+                  </svg>
                   <span>Politici</span>
                 </div>
                 <div class="card-body">
                   <h5 class="card-title">Lorem ipsum dolor sit amet</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -249,17 +285,23 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
+                  <svg class="icon">
+                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
+                  </svg>
                   <span>Luoghi</span>
                 </div>
                 <div class="card-body">
-                  <h5 class="card-title">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</h5>
+                  <h5 class="card-title">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…
+                  </h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -286,11 +328,14 @@ title: Template Amministrazione
                 <div class="card-body">
                   <h5 class="card-title big-heading">Anagrafe e stato civile</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -304,11 +349,14 @@ title: Template Amministrazione
                 <div class="card-body">
                   <h5 class="card-title big-heading">Cultura e tempo libero</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -322,11 +370,14 @@ title: Template Amministrazione
                 <div class="card-body">
                   <h5 class="card-title big-heading">Vita lavorativa</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -340,11 +391,14 @@ title: Template Amministrazione
                 <div class="card-body">
                   <h5 class="card-title big-heading">Attività produttiva e commercio</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -358,11 +412,14 @@ title: Template Amministrazione
                 <div class="card-body">
                   <h5 class="card-title big-heading">Appalti pubblici</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -376,11 +433,14 @@ title: Template Amministrazione
                 <div class="card-body">
                   <h5 class="card-title big-heading">Catasto e urbanistica</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -394,11 +454,14 @@ title: Template Amministrazione
                 <div class="card-body">
                   <h5 class="card-title big-heading">Turismo</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -412,11 +475,14 @@ title: Template Amministrazione
                 <div class="card-body">
                   <h5 class="card-title big-heading">Mobilità e trasporti</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -430,11 +496,14 @@ title: Template Amministrazione
                 <div class="card-body">
                   <h5 class="card-title big-heading">Educazione e formazione</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -448,11 +517,14 @@ title: Template Amministrazione
                 <div class="card-body">
                   <h5 class="card-title big-heading">Giustizia e sicurezza pubblica</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -466,11 +538,14 @@ title: Template Amministrazione
                 <div class="card-body">
                   <h5 class="card-title big-heading">Tributi e finanze</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -484,11 +559,14 @@ title: Template Amministrazione
                 <div class="card-body">
                   <h5 class="card-title big-heading">Ambiente</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -502,11 +580,14 @@ title: Template Amministrazione
                 <div class="card-body">
                   <h5 class="card-title big-heading">Salute, benessere e assistenza</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -520,11 +601,14 @@ title: Template Amministrazione
                 <div class="card-body">
                   <h5 class="card-title big-heading">Autorizzazioni</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -538,11 +622,14 @@ title: Template Amministrazione
                 <div class="card-body">
                   <h5 class="card-title big-heading">Agricoltura</h5>
                   <p class="card-text">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
+                    <svg class="icon">
+                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
+                    </svg>
                   </a>
                 </div>
               </div>
@@ -561,15 +648,21 @@ title: Template Amministrazione
         </div>
         <div class="row">
           <div class="col text-center">
-            <a href="#"
-              ><span class="chip chip-simple chip-primary"><span class="chip-label">Cultura</span></span></a
-            >
-            <a href="#"
-              ><span class="chip chip-simple chip-primary"><span class="chip-label">Muoversi</span></span></a
-            >
-            <a href="#"
-              ><span class="chip chip-simple chip-primary"><span class="chip-label">Argomento di esempio</span></span></a
-            >
+            <a href="#">
+              <span class="chip chip-simple chip-primary">
+                <span class="chip-label">Cultura</span>
+              </span>
+            </a>
+            <a href="#">
+              <span class="chip chip-simple chip-primary">
+                <span class="chip-label">Muoversi</span>
+              </span>
+            </a>
+            <a href="#">
+              <span class="chip chip-simple chip-primary">
+                <span class="chip-label">Argomento di esempio</span>
+              </span>
+            </a>
           </div>
         </div>
       </div>

--- a/docs/esempi/comuni/template-servizi.html
+++ b/docs/esempi/comuni/template-servizi.html
@@ -136,9 +136,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <span>Scuola e formazione</span>
                 </div>
                 <div class="card-body">
@@ -148,9 +146,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="{{ site.baseurl }}/docs/esempi/comuni/template-servizi-servizio/">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -163,9 +159,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-user"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-user"></use></svg>
                   <span>Funzionari amministrativi</span>
                 </div>
                 <div class="card-body">
@@ -175,9 +169,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -190,9 +182,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <span>Uffici</span>
                 </div>
                 <div class="card-body">
@@ -202,9 +192,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -217,9 +205,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <span>Luoghi</span>
                 </div>
                 <div class="card-body">
@@ -227,9 +213,7 @@ title: Template Amministrazione
                   <p class="card-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed.</p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -242,9 +226,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-user"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-user"></use></svg>
                   <span>Politici</span>
                 </div>
                 <div class="card-body">
@@ -254,9 +236,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -269,9 +249,7 @@ title: Template Amministrazione
               <div class="card card-bg card-big rounded shadow">
                 <div class="flag-icon invisible"></div>
                 <div class="etichetta">
-                  <svg class="icon">
-                    <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use>
-                  </svg>
+                  <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pa"></use></svg>
                   <span>Luoghi</span>
                 </div>
                 <div class="card-body">
@@ -281,9 +259,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -314,9 +290,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -334,9 +308,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -354,9 +326,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -374,9 +344,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -394,9 +362,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -414,9 +380,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -434,9 +398,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -454,9 +416,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -474,9 +434,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -494,9 +452,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -514,9 +470,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -534,9 +488,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -554,9 +506,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -574,9 +524,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>
@@ -594,9 +542,7 @@ title: Template Amministrazione
                   </p>
                   <a class="read-more" href="#">
                     <span class="text">Leggi di più</span>
-                    <svg class="icon">
-                      <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                    </svg>
+                    <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                   </a>
                 </div>
               </div>

--- a/docs/esempi/hero/index.html
+++ b/docs/esempi/hero/index.html
@@ -240,9 +240,7 @@ title: Hero
                 <a class="read-more" href="#">
                   <span class="text">Leggi di più</span>
                   <span class="visually-hidden">su Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</span>
-                  <svg class="icon">
-                    <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-                  </svg>
+                  <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
                 </a>
               </div>
             </div>

--- a/docs/esempi/navscroll/index.html
+++ b/docs/esempi/navscroll/index.html
@@ -331,28 +331,28 @@ title: NavScroll
               <h4><a href="#" title="Vai alla pagina: Seguici su">Seguici su</a></h4>
               <ul class="list-inline text-left social">
                 <li class="list-inline-item">
-                  <a class="p-2 text-white" href="#" target="_blank"
-                    ><svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-designers-italia"></use></svg
-                    ><span class="visually-hidden">Designers Italia</span></a
-                  >
+                  <a class="p-2 text-white" href="#" target="_blank">
+                    <svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-designers-italia"></use></svg>
+                    <span class="visually-hidden">Designers Italia</span>
+                  </a>
                 </li>
                 <li class="list-inline-item">
-                  <a class="p-2 text-white" href="#" target="_blank"
-                    ><svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-twitter"></use></svg
-                    ><span class="visually-hidden">Twitter</span></a
-                  >
+                  <a class="p-2 text-white" href="#" target="_blank">
+                    <svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-twitter"></use></svg>
+                    <span class="visually-hidden">Twitter</span>
+                  </a>
                 </li>
                 <li class="list-inline-item">
-                  <a class="p-2 text-white" href="#" target="_blank"
-                    ><svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-medium"></use></svg
-                    ><span class="visually-hidden">Medium</span></a
-                  >
+                  <a class="p-2 text-white" href="#" target="_blank">
+                    <svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-medium"></use></svg>
+                    <span class="visually-hidden">Medium</span>
+                  </a>
                 </li>
                 <li class="list-inline-item">
-                  <a class="p-2 text-white" href="#" target="_blank"
-                    ><svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-behance"></use></svg
-                    ><span class="visually-hidden">Behance</span></a
-                  >
+                  <a class="p-2 text-white" href="#" target="_blank">
+                    <svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-behance"></use></svg>
+                    <span class="visually-hidden">Behance</span>
+                  </a>
                 </li>
               </ul>
             </div>

--- a/docs/esempi/navscroll/index.html
+++ b/docs/esempi/navscroll/index.html
@@ -237,9 +237,7 @@ title: NavScroll
           <div class="col-sm-12">
             <div class="it-brand-wrapper">
               <a href="#">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
                 <div class="it-brand-text">
                   <h2 class="no_toc">Lorem Ipsum</h2>
                   <h3 class="no_toc d-none d-md-block">Inserire qui la tag line</h3>

--- a/docs/esempi/notifications/index.html
+++ b/docs/esempi/notifications/index.html
@@ -149,9 +149,7 @@ nonbundle: false
   </h5>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</p>
   <button type="button" class="btn notification-close" data-bs-dismiss="notification">
-    <svg class="icon">
-      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-    </svg>
+    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
     <span class="visually-hidden">Chiudi notifica: Dismissable Top Fix</span>
   </button>
 </div>
@@ -164,9 +162,7 @@ nonbundle: false
   </h5>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</p>
   <button type="button" class="btn notification-close" data-bs-dismiss="notification">
-    <svg class="icon">
-      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-    </svg>
+    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
     <span class="visually-hidden">Chiudi notifica: Dismissable Bottom Fix</span>
   </button>
 </div>
@@ -179,9 +175,7 @@ nonbundle: false
   </h5>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</p>
   <button type="button" class="btn notification-close" data-bs-dismiss="notification">
-    <svg class="icon">
-      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-    </svg>
+    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
     <span class="visually-hidden">Chiudi notifica: Dismissable Left Fix</span>
   </button>
 </div>
@@ -194,9 +188,7 @@ nonbundle: false
   </h5>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</p>
   <button type="button" class="btn notification-close" data-bs-dismiss="notification">
-    <svg class="icon">
-      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-    </svg>
+    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
     <span class="visually-hidden">Chiudi notifica: Dismissable Right Fix</span>
   </button>
 </div>

--- a/docs/esempi/notifications/index.html
+++ b/docs/esempi/notifications/index.html
@@ -79,24 +79,20 @@ nonbundle: false
 
 <div class="notification with-icon success" role="alert" id="notificationIcnTxt" data-bs-timeout="7000" aria-labelledby="not1-title">
   <h5 id="not1-title">
-    <svg class="icon">
-      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check-circle" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check-circle"></use></svg
-    >Notification icon/text
+    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check-circle" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check-circle"></use></svg>
+    Notification icon/text
   </h5>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</p>
 </div>
 
 <div class="notification dismissable with-icon success fade" role="alert" id="notificationDism" aria-labelledby="not6-title">
   <h5 id="not6-title">
-    <svg class="icon">
-      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check-circle" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check-circle"></use></svg
-    >Notification Dismissable
+    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check-circle" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check-circle"></use></svg>
+      Notification Dismissable
   </h5>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</p>
   <button type="button" class="btn notification-close" data-bs-dismiss="notification">
-    <svg class="icon">
-      <use xlink="{{ site.baseurl }}/dist/svg/sprites.svg#it-close" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use>
-    </svg>
+    <svg class="icon"><use xlink="{{ site.baseurl }}/dist/svg/sprites.svg#it-close" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg>
     <span class="visually-hidden">Chiudi notifica: Titolo notification</span>
   </button>
 </div>
@@ -105,36 +101,32 @@ nonbundle: false
 <!-- col2 -->
 <div class="notification top-fix with-icon success fade" role="alert" id="notificationTop" aria-labelledby="not2-title">
   <h5 id="not2-title">
-    <svg class="icon">
-      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check-circle" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check-circle"></use></svg
-    >Notification Top Fix
+    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check-circle" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check-circle"></use></svg>
+    Notification Top Fix
   </h5>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</p>
 </div>
 
 <div class="notification bottom-fix with-icon error fade" role="alert" id="notificationBottom" aria-labelledby="not3-title">
   <h5 id="not3-title">
-    <svg class="icon">
-      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close-circle" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close-circle"></use></svg
-    >Notification Bottom Fix
+    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close-circle" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close-circle"></use></svg>
+    Notification Bottom Fix
   </h5>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</p>
 </div>
 
 <div class="notification left-fix with-icon info fade" role="alert" id="notificationLeft" aria-labelledby="not4-title">
   <h5 id="not4-title">
-    <svg class="icon">
-      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use></svg
-    >Notification Left Fix
+    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use></svg>
+    Notification Left Fix
   </h5>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</p>
 </div>
 
 <div class="notification right-fix with-icon warning fade" role="alert" id="notificationRight" aria-labelledby="not5-title">
   <h5 id="not5-title">
-    <svg class="icon">
-      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-error" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-error"></use></svg
-    >Notification Right Fix
+    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-error" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-error"></use></svg>
+    Notification Right Fix
   </h5>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</p>
 </div>
@@ -143,9 +135,8 @@ nonbundle: false
 <!-- col3 -->
 <div class="notification dismissable top-fix with-icon success fade" role="alert" id="notificationDismTopFix" aria-labelledby="not7-title">
   <h5 id="not7-title">
-    <svg class="icon">
-      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-error" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-error"></use></svg
-    >Dismissable Top Fix
+    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-error" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-error"></use></svg>
+    Dismissable Top Fix
   </h5>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</p>
   <button type="button" class="btn notification-close" data-bs-dismiss="notification">
@@ -156,9 +147,8 @@ nonbundle: false
 
 <div class="notification dismissable bottom-fix with-icon error fade" role="alert" id="notificationDismBotFix" aria-labelledby="not8-title">
   <h5 id="not8-title">
-    <svg class="icon">
-      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close-circle" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close-circle"></use></svg
-    >Dismissable Bottom Fix
+    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close-circle" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close-circle"></use></svg>
+    Dismissable Bottom Fix
   </h5>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</p>
   <button type="button" class="btn notification-close" data-bs-dismiss="notification">
@@ -169,9 +159,8 @@ nonbundle: false
 
 <div class="notification dismissable left-fix with-icon info fade" role="alert" id="notificationDismLftFix" aria-labelledby="not9-title">
   <h5 id="not9-title">
-    <svg class="icon">
-      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use></svg
-    >Dismissable Left Fix
+    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-info-circle"></use></svg>
+    Dismissable Left Fix
   </h5>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</p>
   <button type="button" class="btn notification-close" data-bs-dismiss="notification">
@@ -182,9 +171,8 @@ nonbundle: false
 
 <div class="notification dismissable right-fix with-icon warning fade" role="alert" id="notificationDismRgtFix" aria-labelledby="not10-title">
   <h5 id="not10-title">
-    <svg class="icon">
-      <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-error" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-error"></use></svg
-    >Dismissable Right Fix
+    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-error" xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-error"></use></svg>
+    Dismissable Right Fix
   </h5>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor…</p>
   <button type="button" class="btn notification-close" data-bs-dismiss="notification">

--- a/docs/esempi/sticky-target/index.html
+++ b/docs/esempi/sticky-target/index.html
@@ -82,18 +82,14 @@ title: Sticky
                 data-bs-toggle="navbarcollapsible"
                 data-bs-target="#navC1"
               >
-                <svg class="icon">
-                  <use href="/dist/svg/sprites.svg#it-burger"></use>
-                </svg>
+                <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-burger"></use></svg>
               </button>
               <div class="navbar-collapsable" id="navC1" style="display: none">
                 <div class="overlay" style="display: none"></div>
                 <div class="close-div">
                   <button class="btn close-menu" type="button">
                     <span class="visually-hidden">Nascondi la navigazione</span>
-                    <svg class="icon">
-                      <use href="/dist/svg/sprites.svg#it-close-big"></use>
-                    </svg>
+                    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close-big"></use></svg>
                   </button>
                 </div>
                 <div class="menu-wrapper">

--- a/docs/esempi/template-vuoto/index.html
+++ b/docs/esempi/template-vuoto/index.html
@@ -41,9 +41,9 @@ title: Template vuoto
                       <div class="link-list-wrapper">
                         <ul class="link-list">
                           <li>
-                            <a class="dropdown-item list-item" href="#"
-                              ><span>ITA <span class="visually-hidden">selezionata</span></span></a
-                            >
+                            <a class="dropdown-item list-item" href="#">
+                              <span>ITA <span class="visually-hidden">selezionata</span></span>
+                            </a>
                           </li>
                           <li>
                             <a class="dropdown-item list-item" href="#"><span>ENG</span></a>
@@ -367,28 +367,28 @@ title: Template vuoto
               <h4><a href="#" title="Vai alla pagina: Seguici su">Seguici su</a></h4>
               <ul class="list-inline text-left social">
                 <li class="list-inline-item">
-                  <a class="p-2 text-white" href="#" target="_blank"
-                    ><svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-designers-italia"></use></svg
-                    ><span class="visually-hidden">Designers Italia</span></a
-                  >
+                  <a class="p-2 text-white" href="#" target="_blank">
+                    <svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-designers-italia"></use></svg>
+                    <span class="visually-hidden">Designers Italia</span>
+                  </a>
                 </li>
                 <li class="list-inline-item">
-                  <a class="p-2 text-white" href="#" target="_blank"
-                    ><svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-twitter"></use></svg
-                    ><span class="visually-hidden">Twitter</span></a
-                  >
+                  <a class="p-2 text-white" href="#" target="_blank">
+                    <svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-twitter"></use></svg>
+                    <span class="visually-hidden">Twitter</span>
+                  </a>
                 </li>
                 <li class="list-inline-item">
-                  <a class="p-2 text-white" href="#" target="_blank"
-                    ><svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-medium"></use></svg
-                    ><span class="visually-hidden">Medium</span></a
-                  >
+                  <a class="p-2 text-white" href="#" target="_blank">
+                    <svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-medium"></use></svg>
+                    <span class="visually-hidden">Medium</span>
+                  </a>
                 </li>
                 <li class="list-inline-item">
-                  <a class="p-2 text-white" href="#" target="_blank"
-                    ><svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-behance"></use></svg
-                    ><span class="visually-hidden">Behance</span></a
-                  >
+                  <a class="p-2 text-white" href="#" target="_blank">
+                    <svg class="icon icon-sm icon-white align-top"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-behance"></use></svg>
+                    <span class="visually-hidden">Behance</span>
+                  </a>
                 </li>
               </ul>
             </div>

--- a/docs/esempi/template-vuoto/index.html
+++ b/docs/esempi/template-vuoto/index.html
@@ -86,23 +86,17 @@ title: Template vuoto
                   <ul>
                     <li>
                       <a href="#" aria-label="Facebook" target="_blank">
-                        <svg class="icon">
-                          <use href="/dist/svg/sprites.svg#it-facebook"></use>
-                        </svg>
+                        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-facebook"></use></svg>
                       </a>
                     </li>
                     <li>
                       <a href="#" aria-label="Github" target="_blank">
-                        <svg class="icon">
-                          <use href="/dist/svg/sprites.svg#it-github"></use>
-                        </svg>
+                        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-github"></use></svg>
                       </a>
                     </li>
                     <li>
                       <a href="#" aria-label="Twitter" target="_blank">
-                        <svg class="icon">
-                          <use href="/dist/svg/sprites.svg#it-twitter"></use>
-                        </svg>
+                        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-twitter"></use></svg>
                       </a>
                     </li>
                   </ul>
@@ -110,9 +104,7 @@ title: Template vuoto
                 <div class="it-search-wrapper">
                   <span class="d-none d-md-block">Cerca</span>
                   <a class="search-link rounded-icon" aria-label="Cerca nel sito" href="#">
-                    <svg class="icon">
-                      <use href="/dist/svg/sprites.svg#it-search"></use>
-                    </svg>
+                    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-search"></use></svg>
                   </a>
                 </div>
               </div>
@@ -135,18 +127,14 @@ title: Template vuoto
                 aria-label="Mostra/Nascondi la navigazione"
                 data-target="#navC1"
               >
-                <svg class="icon">
-                  <use href="/dist/svg/sprites.svg#it-burger"></use>
-                </svg>
+                <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-burger"></use></svg>
               </button>
               <div class="navbar-collapsable" id="navC1" style="display: none">
                 <div class="overlay" style="display: none"></div>
                 <div class="close-div">
                   <button class="btn close-menu" type="button">
                     <span class="visually-hidden">Nascondi la navigazione</span>
-                    <svg class="icon">
-                      <use href="/dist/svg/sprites.svg#it-close-big"></use>
-                    </svg>
+                    <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close-big"></use></svg>
                   </button>
                 </div>
                 <div class="menu-wrapper">

--- a/docs/esempi/template-vuoto/index.html
+++ b/docs/esempi/template-vuoto/index.html
@@ -285,9 +285,7 @@ title: Template vuoto
           <div class="col-sm-12">
             <div class="it-brand-wrapper">
               <a href="#">
-                <svg class="icon">
-                  <use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
                 <div class="it-brand-text">
                   <h2 class="no_toc">Lorem Ipsum</h2>
                   <h3 class="no_toc d-none d-md-block">Inserire qui la tag line</h3>

--- a/docs/form/transfer.md
+++ b/docs/form/transfer.md
@@ -110,21 +110,15 @@ Nell'esempio che segue la struttura è colonnare simmetrica nella versione deskt
       <!-- transfer buttons-->
       <div class="it-transfer-buttons">
         <a class="transfer" href="#" aria-label="Sposta avanti">
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-right"></use></svg>
         </a>
         <span class="visually-hidden">Label for aroow right</span>
         <a class="backtransfer" href="#" aria-label="Sposta indietro">
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-left"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-arrow-left"></use></svg>
         </a>
         <span class="visually-hidden">Label for aroow left</span>
         <a class="reset" href="#" aria-label="Reset">
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
         </a>
         <span class="visually-hidden">Label for reset icon</span>
       </div>

--- a/docs/menu-di-navigazione/footer.md
+++ b/docs/menu-di-navigazione/footer.md
@@ -22,9 +22,7 @@ Potrebbe anche contenere riferimenti alle pagine social dell'amministrazione.
           <div class="col-sm-12">
             <div class="it-brand-wrapper">
               <a href="#" class="" data-focus-mouse="false">
-                <svg class="icon">
-                  <use xlink:href="{{site.baseurl}}/dist/svg/sprites.svg#it-code-circle"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
                 <div class="it-brand-text">
                   <h2 class="no_toc">Lorem Ipsum</h2>
                   <h3 class="no_toc d-none d-md-block">Inserire qui la tag line</h3>
@@ -161,9 +159,7 @@ Potrebbe anche contenere riferimenti alle pagine social dell'amministrazione.
           <div class="col-sm-12">
             <div class="it-brand-wrapper">
               <a href="#" class="" data-focus-mouse="false">
-                <svg class="icon">
-                  <use xlink:href="{{site.baseurl}}/dist/svg/sprites.svg#it-code-circle"></use>
-                </svg>
+                <svg class="icon"><use xlink:href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
                 <div class="it-brand-text">
                   <h2 class="no_toc">Lorem Ipsum</h2>
                   <h3 class="no_toc d-none d-md-block">Inserire qui la tag line</h3>

--- a/docs/organizzare-i-contenuti/liste-di-immagini.md
+++ b/docs/organizzare-i-contenuti/liste-di-immagini.md
@@ -40,9 +40,7 @@ Per utilizzare la didascalia sovrapposta è sufficiente aggiungere la classe `.i
         </div>
         <span class="it-griditem-text-wrapper">
           <span class="it-griditem-text">Didascalia</span>
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
         </span>
       </a>
     </div>
@@ -57,9 +55,7 @@ Per utilizzare la didascalia sovrapposta è sufficiente aggiungere la classe `.i
         </div>
         <span class="it-griditem-text-wrapper">
           <span class="it-griditem-text">Didascalia</span>
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
         </span>
       </a>
     </div>
@@ -166,9 +162,7 @@ Per la corretta formattazione degli spazi di questo tipo di griglia, occorre agg
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -183,9 +177,7 @@ Per la corretta formattazione degli spazi di questo tipo di griglia, occorre agg
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -200,9 +192,7 @@ Per la corretta formattazione degli spazi di questo tipo di griglia, occorre agg
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -217,9 +207,7 @@ Per la corretta formattazione degli spazi di questo tipo di griglia, occorre agg
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -234,9 +222,7 @@ Per la corretta formattazione degli spazi di questo tipo di griglia, occorre agg
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -251,9 +237,7 @@ Per la corretta formattazione degli spazi di questo tipo di griglia, occorre agg
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -289,9 +273,7 @@ Per utilizzare l'immagine orizzontale, occorre aggiungere la classe `.it-grid-it
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -308,9 +290,7 @@ Per utilizzare l'immagine orizzontale, occorre aggiungere la classe `.it-grid-it
               </div>
               <span class="it-griditem-text-wrapper">
                 <span class="it-griditem-text">Didascalia</span>
-                <svg class="icon">
-                  <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-                </svg>
+                <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
               </span>
             </a>
           </div>
@@ -325,9 +305,7 @@ Per utilizzare l'immagine orizzontale, occorre aggiungere la classe `.it-grid-it
               </div>
               <span class="it-griditem-text-wrapper">
                 <span class="it-griditem-text">Didascalia</span>
-                <svg class="icon">
-                  <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-                </svg>
+                <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
               </span>
             </a>
           </div>
@@ -342,9 +320,7 @@ Per utilizzare l'immagine orizzontale, occorre aggiungere la classe `.it-grid-it
               </div>
               <span class="it-griditem-text-wrapper">
                 <span class="it-griditem-text">Didascalia</span>
-                <svg class="icon">
-                  <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-                </svg>
+                <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
               </span>
             </a>
           </div>
@@ -377,9 +353,7 @@ Aggiungendo `data-bs-toggle="masonry"` al contenitore `row`, verrà attivato l'e
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -394,9 +368,7 @@ Aggiungendo `data-bs-toggle="masonry"` al contenitore `row`, verrà attivato l'e
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -411,9 +383,7 @@ Aggiungendo `data-bs-toggle="masonry"` al contenitore `row`, verrà attivato l'e
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -428,9 +398,7 @@ Aggiungendo `data-bs-toggle="masonry"` al contenitore `row`, verrà attivato l'e
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -445,9 +413,7 @@ Aggiungendo `data-bs-toggle="masonry"` al contenitore `row`, verrà attivato l'e
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -462,9 +428,7 @@ Aggiungendo `data-bs-toggle="masonry"` al contenitore `row`, verrà attivato l'e
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -479,9 +443,7 @@ Aggiungendo `data-bs-toggle="masonry"` al contenitore `row`, verrà attivato l'e
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -496,9 +458,7 @@ Aggiungendo `data-bs-toggle="masonry"` al contenitore `row`, verrà attivato l'e
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -513,9 +473,7 @@ Aggiungendo `data-bs-toggle="masonry"` al contenitore `row`, verrà attivato l'e
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -530,9 +488,7 @@ Aggiungendo `data-bs-toggle="masonry"` al contenitore `row`, verrà attivato l'e
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -547,9 +503,7 @@ Aggiungendo `data-bs-toggle="masonry"` al contenitore `row`, verrà attivato l'e
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>
@@ -564,9 +518,7 @@ Aggiungendo `data-bs-toggle="masonry"` al contenitore `row`, verrà attivato l'e
           </div>
           <span class="it-griditem-text-wrapper">
             <span class="it-griditem-text">Didascalia</span>
-            <svg class="icon">
-              <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-            </svg>
+            <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
           </span>
         </a>
       </div>

--- a/docs/organizzare-i-contenuti/liste.md
+++ b/docs/organizzare-i-contenuti/liste.md
@@ -83,9 +83,7 @@ L'elemento `.it-rounded-icon` con all'interno la relativa icona, precede l'eleme
     <li>
       <div class="list-item">
         <div class="it-rounded-icon">
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-folder"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-folder"></use></svg>
         </div>
         <div class="it-right-zone"><span class="text">Testo</span>
         </div>
@@ -94,9 +92,7 @@ L'elemento `.it-rounded-icon` con all'interno la relativa icona, precede l'eleme
     <li>
       <a href="#" class="list-item">
         <div class="it-rounded-icon">
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-folder"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-folder"></use></svg>
         </div>
         <div class="it-right-zone"><span class="text">Link</span>
         </div>
@@ -105,9 +101,7 @@ L'elemento `.it-rounded-icon` con all'interno la relativa icona, precede l'eleme
     <li>
       <a class="list-item active" href="#">
         <div class="it-rounded-icon">
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-folder"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-folder"></use></svg>
         </div>
         <div class="it-right-zone"><span class="text">Link attivo</span>
         </div>
@@ -166,9 +160,7 @@ L'elemento `.icon` con all'interno la relativa icona segue l'elemento `.text` ch
       <a href="#" class="list-item">
         <div class="it-right-zone">
           <span class="text">Link</span>
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-chevron-right"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-chevron-right"></use></svg>
         </div>
       </a>
     </li>
@@ -176,9 +168,7 @@ L'elemento `.icon` con all'interno la relativa icona segue l'elemento `.text` ch
       <a class="active list-item" href="#">
         <div class="it-right-zone">
           <span class="text">Link attivo</span>
-          <svg class="icon">
-            <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-chevron-right"></use>
-          </svg>
+          <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-chevron-right"></use></svg>
         </div>
       </a>
     </li>
@@ -200,19 +190,13 @@ L'elemento `.it-multiple` con all'interno le relative icone, segue l'elemento `.
           <span class="text">Testo</span>
           <span class="it-multiple">
             <a href="#" aria-label="Testo - Azione 1">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
             <a href="#" aria-label="Testo - Azione 2">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
             <a href="#" aria-label="Testo - Azione 3">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
           </span>
         </div>
@@ -226,19 +210,13 @@ L'elemento `.it-multiple` con all'interno le relative icone, segue l'elemento `.
           </a>
           <span class="it-multiple">
             <a href="#" aria-label="Link - Azione 1">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
             <a href="#" aria-label="Link - Azione 2">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
             <a href="#" aria-label="Link - Azione 3">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
           </span>
         </div>
@@ -252,19 +230,13 @@ L'elemento `.it-multiple` con all'interno le relative icone, segue l'elemento `.
           </a>
           <span class="it-multiple">
             <a href="#" aria-label="Link attivo - Azione 1">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
             <a href="#" aria-label="Link attivo - Azione 2">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
             <a href="#" aria-label="Link attivo - Azione 3">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
           </span>
         </div>
@@ -339,19 +311,13 @@ Per il testo aggiuntivo, utilizzare il tag `<em>` all'interno dell'elemento `.te
           <span class="it-multiple">
             <span class="metadata">metadata testo</span>
             <a href="#" aria-label="Testo - Azione 1">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
             <a href="#" aria-label="Testo - Azione 2">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
             <a href="#" aria-label="Testo - Azione 3">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
           </span>
         </div>
@@ -364,19 +330,13 @@ Per il testo aggiuntivo, utilizzare il tag `<em>` all'interno dell'elemento `.te
           <span class="it-multiple">
             <span class="metadata"><a href="#">metadata link</a></span>
             <a href="#" aria-label="Testo 2 - Azione 1">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
             <a href="#" aria-label="Testo 2 - Azione 2">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
             <a href="#" aria-label="Testo 2 - Azione 3">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
           </span>
         </div>
@@ -389,19 +349,13 @@ Per il testo aggiuntivo, utilizzare il tag `<em>` all'interno dell'elemento `.te
           <span class="it-multiple">
             <span class="metadata"><a href="#">metadata link</a></span>
             <a href="#" aria-label="Link - Azione 1">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
             <a href="#" aria-label="Link - Azione 2">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
             <a href="#" aria-label="Link - Azione 3">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
           </span>
         </div>
@@ -414,19 +368,13 @@ Per il testo aggiuntivo, utilizzare il tag `<em>` all'interno dell'elemento `.te
           <span class="it-multiple">
             <span class="metadata">metadata testo</span>
             <a href="#" aria-label="Link attivo - Azione 1">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
             <a href="#" aria-label="Link attivo - Azione 2">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
             <a href="#" aria-label="Link attivo - Azione 3">
-              <svg class="icon">
-                <use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use>
-              </svg>
+              <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
           </span>
         </div>


### PR DESCRIPTION
## Descrizione

Come da descrizione, rivisto lint spazi e ritorni a capo specialmente tag `<a>` e `<svg>` in giro per tutti i file. Revisione a meno fatta via `regex`. 

## Motivazione

Ottimizzare lettura codice. 

Specialmente negli esempi in documentazione, in VSCode, c'è il tema tag `<svg>`: se il seguente`<use>` è a capo invece che essere in linea si sottolineano nell'editor tutte le righe di codice successive.  

## Segnalazioni

- C'è qualche incongruenza nell'uso icone, alcune con `href` altre con `xlink:href`, alcune con `site.baseurl`, altre senza.
- Non sono sicuro se ha senso ottimizzare anche i template html degli esempi. 

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
