### PR TITLE
fix: navbar mobile focus

### DIFF
--- a/src/js/plugins/navbar-collapsible.js
+++ b/src/js/plugins/navbar-collapsible.js
@@ -47,7 +47,6 @@ const SELECTOR_MEGAMENUNAVLINK = '.nav-item .list-item'
 const SELECTOR_HEADINGLINK = '.it-heading-link'
 const SELECTOR_FOOTERLINK = '.it-footer-link'
 
-
 class NavBarCollapsible extends BaseComponent {
   constructor(element) {
     super(element)
@@ -65,7 +64,10 @@ class NavBarCollapsible extends BaseComponent {
     this._menuWrapper = SelectorEngine.findOne(SELECTOR_MENU_WRAPPER, this._element)
     this._overlay = null
     this._setOverlay()
-    this._menuItems = SelectorEngine.find([SELECTOR_NAVLINK, SELECTOR_MEGAMENUNAVLINK, SELECTOR_HEADINGLINK, SELECTOR_FOOTERLINK, SELECTOR_BTN_MENU_CLOSE].join(','), this._element)
+    this._menuItems = SelectorEngine.find(
+      [SELECTOR_NAVLINK, SELECTOR_MEGAMENUNAVLINK, SELECTOR_HEADINGLINK, SELECTOR_FOOTERLINK, SELECTOR_BTN_MENU_CLOSE].join(','),
+      this._element
+    )
 
     this._bindEvents()
   }

--- a/src/js/plugins/navbar-collapsible.js
+++ b/src/js/plugins/navbar-collapsible.js
@@ -44,6 +44,9 @@ const SELECTOR_OVERLAY = '.overlay'
 const SELECTOR_MENU_WRAPPER = '.menu-wrapper'
 const SELECTOR_NAVLINK = '.nav-link'
 const SELECTOR_MEGAMENUNAVLINK = '.nav-item .list-item'
+const SELECTOR_HEADINGLINK = '.it-heading-link'
+const SELECTOR_FOOTERLINK = '.it-footer-link'
+
 
 class NavBarCollapsible extends BaseComponent {
   constructor(element) {
@@ -62,7 +65,7 @@ class NavBarCollapsible extends BaseComponent {
     this._menuWrapper = SelectorEngine.findOne(SELECTOR_MENU_WRAPPER, this._element)
     this._overlay = null
     this._setOverlay()
-    this._menuItems = SelectorEngine.find([SELECTOR_NAVLINK, SELECTOR_MEGAMENUNAVLINK, SELECTOR_BTN_MENU_CLOSE].join(','), this._element)
+    this._menuItems = SelectorEngine.find([SELECTOR_NAVLINK, SELECTOR_MEGAMENUNAVLINK, SELECTOR_HEADINGLINK, SELECTOR_FOOTERLINK, SELECTOR_BTN_MENU_CLOSE].join(','), this._element)
 
     this._bindEvents()
   }

--- a/src/js/plugins/navbar-collapsible.js
+++ b/src/js/plugins/navbar-collapsible.js
@@ -42,7 +42,7 @@ const SELECTOR_BTN_MENU_CLOSE = '.close-menu'
 const SELECTOR_BTN_BACK = '.it-back-button'
 const SELECTOR_OVERLAY = '.overlay'
 const SELECTOR_MENU_WRAPPER = '.menu-wrapper'
-const SELECTOR_NAVLINK = 'a.nav-link'
+const SELECTOR_NAVLINK = '.nav-link'
 const SELECTOR_MEGAMENUNAVLINK = '.nav-item .list-item'
 
 class NavBarCollapsible extends BaseComponent {


### PR DESCRIPTION
## Contesto

I button della navbar (toggle dropdown, toggle megamenu) devono essere "focusable" anche su mobile, nell'ordine corretto.

## Descrizione

Nel plugin `navbar-collapsible.js` il `SELECTOR_NAVLINK` può essere anche `<button>`, non solo un `<a>` come adesso. Vedi casi di dropdown e megamenu. 

🔴 È un bug che oggi preveda solo `a.nav-link`: se provi infatti a navigare da tastiera la navbar mobile sei "trapped" sull'icona di chiusura se hai solo buttons nella navbar (es: https://designers.italia.it). E anche ci fossero `a`, salteresti sempre i toggle di tipo `button`.

**In questa PR ho reso agnostico il selettore togliendo il tag `a` e lasciando la sola classe `.nav-link`.** 

🟠 Una alternativa sarebbe avere un selettore multiplo di `a.nav-link` e `button.nav-link` se preferiamo limitare. 
@astagi lascio a te la scelta. 

------

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
