### PR TITLE
fix: removed forced underline

### DIFF
--- a/src/scss/custom/_type.scss
+++ b/src/scss/custom/_type.scss
@@ -213,8 +213,3 @@ small,
 .initialism {
   font-size: 90%;
 }
-
-// force text decoration for links with `.text-decoration-none` class
-a.text-decoration-none:hover {
-  text-decoration: underline;
-}


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Remove forced `underline` for links with `.text-decoration-none`. Fixes #1045

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [X] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [X] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [X] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [X] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [X] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
