### PR TITLE
fix: callout

### DIFF
--- a/src/scss/custom/_callout.scss
+++ b/src/scss/custom/_callout.scss
@@ -235,7 +235,7 @@
         top: 0.875em;
         border-top: 2px solid;
         position: absolute;
-        width: 250%;
+        width: calc(100% + 23rem);
         left: 100%;
       }
       &:before {


### PR DESCRIPTION
## Descrizione

La modifica corregge la costruzione della linea dopo il titolo nel componente Callout.

## Issue collegata
#1119 

## Checklist

- [ X ] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [ X ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ X ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ X ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

