### PR TITLE
fix: secondary color

### DIFF
--- a/src/scss/utilities/text-colors.scss
+++ b/src/scss/utilities/text-colors.scss
@@ -1,8 +1,13 @@
-//text-color
+// text-color
+// excluding `secondary` due to different colors used for background and text, using a direct class instead
 @each $color, $value in $theme-colors {
-  @if $color != 'white' {
+  @if $color != 'white' and $color != 'secondary' {
     .text-#{$color} {
       color: $value;
     }
   }
+}
+
+.text-secondary {
+  color: $color-text-secondary;
 }


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Escluso il colore `$secondary` dalla funzione utilizzando una classe diretta.

Risolve #1149

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
