### PR TITLE
Feat: aggiunge parametro per dizionario per messaggi di validazione generici localizzati

### DIFF
--- a/src/js/plugins/form-validate.js
+++ b/src/js/plugins/form-validate.js
@@ -13,10 +13,10 @@ const CLASS_NAME_SRONLY = 'sr-only-justvalidate-bi'
 const SELECTOR_SPAN_SRONLY = `.${CLASS_NAME_SRONLY}`
 
 class FormValidate {
-  constructor(selector, config) {
+  constructor(selector, config, dictLocale) {
     this.formSelector = selector
     this.target = document.querySelector(selector)
-    this.validate = new JustValidate(selector, config)
+    this.validate = new JustValidate(selector, config, dictLocale)
     this.config = Object.assign({}, CONFIG_DEFAULT, this.validate.globalConfig)
     this.formItems = []
 

--- a/src/js/plugins/form-validate.js
+++ b/src/js/plugins/form-validate.js
@@ -16,7 +16,13 @@ class FormValidate {
   constructor(selector, config, dictLocale) {
     this.formSelector = selector
     this.target = document.querySelector(selector)
-    this.validate = new JustValidate(selector, config, dictLocale)
+
+    if(dictLocale != undefined)
+      this.validate = new JustValidate(selector, config, dictLocale)
+    else{
+      this.validate = new JustValidate(selector, config)
+    }
+
     this.config = Object.assign({}, CONFIG_DEFAULT, this.validate.globalConfig)
     this.formItems = []
 


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

Con questa PR andiamo ad aggiungere un terzo parametro al costruttore della classe FormValidate che viene passato come parametro al costruttore di JustValidate.  
Questo permette di passare a JustValidate un dizionario per messaggi di validazione generici localizzati.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
