### PR TITLE
fix: is-invalid state on `input`

### DIFF
--- a/docs/form/input-calendario.md
+++ b/docs/form/input-calendario.md
@@ -20,6 +20,6 @@ Assicurarsi di aggiungere alla label la classe **`active`** per impedire la sovr
 {% capture example %}
 <div class="form-group">
     <label class="active" for="dateStandard">Datepicker</label>
-    <input type="date" id="dateStandard" name="dateStandard">
+    <input class="form-control" type="date" id="dateStandard" name="dateStandard">
 </div>
 {% endcapture %}{% include example.html content=example %}

--- a/src/scss/custom/_forms.scss
+++ b/src/scss/custom/_forms.scss
@@ -103,14 +103,11 @@ input[type='url'],
 textarea {
   border: none;
   border-bottom: 1px solid $input-border;
-  border-radius: 0;
   padding: $input-spacing-y $input-spacing-x;
   outline: 0;
-  width: 100%;
   box-shadow: none;
   transition: none;
   -webkit-appearance: none;
-  -webkit-border-radius: 0;
   &::placeholder {
     color: $input-color-placeholder;
   }
@@ -148,12 +145,12 @@ textarea {
   }
   .was-validated &:valid,
   &.is-valid {
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%2300cc85' viewBox='0 0 192 512'%3E%3Cpath d='M435.848 83.466L172.804 346.51l-96.652-96.652c-4.686-4.686-12.284-4.686-16.971 0l-28.284 28.284c-4.686 4.686-4.686 12.284 0 16.971l133.421 133.421c4.686 4.686 12.284 4.686 16.971 0l299.813-299.813c4.686-4.686 4.686-12.284 0-16.971l-28.284-28.284c-4.686-4.686-12.284-4.686-16.97 0z'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%2300cc85' viewBox='0 0 192 512'%3E%3Cpath d='M435.848 83.466L172.804 346.51l-96.652-96.652c-4.686-4.686-12.284-4.686-16.971 0l-28.284 28.284c-4.686 4.686-4.686 12.284 0 16.971l133.421 133.421c4.686 4.686 12.284 4.686 16.971 0l299.813-299.813c4.686-4.686 4.686-12.284 0-16.971l-28.284-28.284c-4.686-4.686-12.284-4.686-16.97 0z'/%3E%3C/svg%3E");
   }
 
   .was-validated &:invalid,
   &.is-invalid {
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23f73e5a' viewBox='0 0 384 512'%3E%3Cpath d='M231.6 256l130.1-130.1c4.7-4.7 4.7-12.3 0-17l-22.6-22.6c-4.7-4.7-12.3-4.7-17 0L192 216.4 61.9 86.3c-4.7-4.7-12.3-4.7-17 0l-22.6 22.6c-4.7 4.7-4.7 12.3 0 17L152.4 256 22.3 386.1c-4.7 4.7-4.7 12.3 0 17l22.6 22.6c4.7 4.7 12.3 4.7 17 0L192 295.6l130.1 130.1c4.7 4.7 12.3 4.7 17 0l22.6-22.6c4.7-4.7 4.7-12.3 0-17L231.6 256z'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23f73e5a' viewBox='0 0 384 512'%3E%3Cpath d='M231.6 256l130.1-130.1c4.7-4.7 4.7-12.3 0-17l-22.6-22.6c-4.7-4.7-12.3-4.7-17 0L192 216.4 61.9 86.3c-4.7-4.7-12.3-4.7-17 0l-22.6 22.6c-4.7 4.7-4.7 12.3 0 17L152.4 256 22.3 386.1c-4.7 4.7-4.7 12.3 0 17l22.6 22.6c4.7 4.7 12.3 4.7 17 0L192 295.6l130.1 130.1c4.7 4.7 12.3 4.7 17 0l22.6-22.6c4.7-4.7 4.7-12.3 0-17L231.6 256z'/%3E%3C/svg%3E");
   }
 
   &.warning {

--- a/src/scss/custom/_forms.scss
+++ b/src/scss/custom/_forms.scss
@@ -116,6 +116,12 @@ textarea {
   }
 }
 
+input[type='date'],
+input[type='datetime-local'],
+input[type='time'] {
+  display: flex;
+}
+
 textarea {
   border: 1px solid $input-border;
   height: auto;

--- a/src/scss/custom/_just-validate.scss
+++ b/src/scss/custom/_just-validate.scss
@@ -33,6 +33,7 @@ button:has(~ .is-invalid),
   padding-right: calc(1.5em + 0.75rem) !important;
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%2300cc85' viewBox='0 0 192 512'%3E%3Cpath d='M435.848 83.466L172.804 346.51l-96.652-96.652c-4.686-4.686-12.284-4.686-16.971 0l-28.284 28.284c-4.686 4.686-4.686 12.284 0 16.971l133.421 133.421c4.686 4.686 12.284 4.686 16.971 0l299.813-299.813c4.686-4.686 4.686-12.284 0-16.971l-28.284-28.284c-4.686-4.686-12.284-4.686-16.97 0z'/%3E%3C/svg%3E");
 }
+
 .input-group-text:has(~ .just-validate-success-field),
 .just-validate-success-field ~ .input-group-text,
 button:has(~ .just-validate-success-field),
@@ -70,13 +71,7 @@ textarea {
     border-bottom-width: 1px;
   }
 }
-input[type='date'] {
-  &.is-invalid {
-    border-bottom: 1px solid #d9364f;
-    padding-right: calc(1.5em + 0.75rem) !important;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23f73e5a' viewBox='0 0 384 512'%3E%3Cpath d='M231.6 256l130.1-130.1c4.7-4.7 4.7-12.3 0-17l-22.6-22.6c-4.7-4.7-12.3-4.7-17 0L192 216.4 61.9 86.3c-4.7-4.7-12.3-4.7-17 0l-22.6 22.6c-4.7 4.7-4.7 12.3 0 17L152.4 256 22.3 386.1c-4.7 4.7-4.7 12.3 0 17l22.6 22.6c4.7 4.7 12.3 4.7 17 0L192 295.6l130.1 130.1c4.7 4.7 12.3 4.7 17 0l22.6-22.6c4.7-4.7 4.7-12.3 0-17L231.6 256z'/%3E%3C/svg%3E");
-  }
-}
+
 input[type='checkbox'],
 input[type='radio'] {
   &.just-validate-success-field {
@@ -85,6 +80,7 @@ input[type='radio'] {
     }
   }
 }
+
 select {
   &.is-invalid {
     border-bottom: 1px solid #d9364f;


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
Per risolvere il problema indicato in #1207 è stato necessario aggiungere la classe `.form-control` al tag `input` di tipo `time` e `date` a cui mancava.

Con l'occasione, è stata fatta pulizia di alcune proprietà duplicate rispetto alla classe `.form-control` ereditata da BS5.

Risolto con l'occasione un bug su tutte le input negli stati `valid` e `invalid` per cui veniva rimosso il colore di sfondo.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
