### PR TITLE
fix: add `.form-control` and disclaimer

### DIFF
--- a/docs/form/input.md
+++ b/docs/form/input.md
@@ -49,7 +49,7 @@ Il campo di input di tipo Password è stato rivisto in chiave accessibilità e r
 {% capture callout %}
 Breaking feature dalla versione **2.11.0**
 
-Quando si utilizza la classe `.form-control-lg` o `.form-control-sm` è necessario aggiungere anche la classe `rounded-0` al tag `<input>` per rimuovere i bordi arrotondati
+Quando si utilizza un campo input è necessario sempre applicare la classe `form-control`.
 
 {% endcapture %}{% include callout.html content=callout type="danger" %}
 

--- a/docs/form/input.md
+++ b/docs/form/input.md
@@ -451,7 +451,7 @@ Il testo corrispondente alla ricerca (_"ite"_, nell'esempio) deve essere racchiu
 {% capture example %}
 <div class="form-group">
   <label for="autocomplete-one" class="visually-hidden">Cerca nel sito</label>
-  <input type="search" class="autocomplete" placeholder="Testo da cercare"
+  <input type="search" class="form-control autocomplete" placeholder="Testo da cercare"
     id="autocomplete-one"
     name="autocomplete-one"
     data-bs-autocomplete="[]">
@@ -522,7 +522,7 @@ Per ottenere una versione grande dell'Autocomplete, indicata ad esempio per inte
 {% capture example %}
 <div class="form-group autocomplete-wrapper-big">
   <label for="autocomplete-two" class="visually-hidden">Cerca nel sito</label>
-  <input type="search" class="autocomplete" placeholder="Testo da cercare"
+  <input type="search" class="form-control autocomplete" placeholder="Testo da cercare"
     id="autocomplete-two"
     name="autocomplete-two"
     data-bs-autocomplete="[]">
@@ -585,7 +585,7 @@ Cerca una regione italiana per verificarne il comportamento.
 {% capture example %}
 <div class="form-group">
   <label for="autocomplete-regioni" class="visually-hidden">Cerca nel sito</label>
-  <input type="search" class="autocomplete" placeholder="Testo da cercare"
+  <input type="search" class="form-control autocomplete" placeholder="Testo da cercare"
     id="autocomplete-regioni"
     name="autocomplete-regioni"
     data-bs-autocomplete='{{ site.data.autocomplete.regioni | jsonify }}'>
@@ -608,7 +608,7 @@ Cerca ad esempio _"Italia"_ per verificarne il comportamento.
 {% capture example %}
 <div class="form-group">
   <label for="autocomplete-test" class="visually-hidden">Cerca nel sito</label>
-  <input type="search" class="autocomplete" placeholder="Testo da cercare"
+  <input type="search" class="form-control autocomplete" placeholder="Testo da cercare"
     id="autocomplete-test"
     name="autocomplete-test"
     data-bs-autocomplete='{{ site.data.autocomplete.nazioni | jsonify }}'>
@@ -646,6 +646,14 @@ Includendo l'elemento all'interno di un `.form-group`, la label assumerà lo ste
 ### Dimensione
 
 È possibile modificare la dimensione dell'elemento utilizzando le classi `.form-control-lg` e `.form-control-sm`, che modificano la grandezza del carattere e la spaziatura interna.
+
+{% capture callout %}
+Breaking feature dalla versione **2.10.0**
+
+Quando si utilizza la classe `.form-control-lg` o `.form-control-sm` è necessario aggiungere anche la classe `rounded-0` al tag `<input>` per rimuovere i bordi arrotondati
+
+{% endcapture %}{% include callout.html content=callout type="danger" %}
+
 
 {% comment %}Example name: Varianti di dimensione {% endcomment %}
 {% capture example %}

--- a/docs/form/input.md
+++ b/docs/form/input.md
@@ -46,6 +46,12 @@ Il campo di input di tipo Password è stato rivisto in chiave accessibilità e r
   - Rimosso il controllo per il Caps-lock inserito, per non interferire con i tasti modificatori delle tecnologie assistive.
   - Aggiunta una variante con misuratore di sicurezza e suggerimenti. 
 {% endcapture %}{% include callout.html content=callout type="danger" %}
+{% capture callout %}
+Breaking feature dalla versione **2.11.0**
+
+Quando si utilizza la classe `.form-control-lg` o `.form-control-sm` è necessario aggiungere anche la classe `rounded-0` al tag `<input>` per rimuovere i bordi arrotondati
+
+{% endcapture %}{% include callout.html content=callout type="danger" %}
 
 {% comment %}Example name: Varianti per tipo {% endcomment %}
 {% capture example %}
@@ -646,14 +652,6 @@ Includendo l'elemento all'interno di un `.form-group`, la label assumerà lo ste
 ### Dimensione
 
 È possibile modificare la dimensione dell'elemento utilizzando le classi `.form-control-lg` e `.form-control-sm`, che modificano la grandezza del carattere e la spaziatura interna.
-
-{% capture callout %}
-Breaking feature dalla versione **2.10.0**
-
-Quando si utilizza la classe `.form-control-lg` o `.form-control-sm` è necessario aggiungere anche la classe `rounded-0` al tag `<input>` per rimuovere i bordi arrotondati
-
-{% endcapture %}{% include callout.html content=callout type="danger" %}
-
 
 {% comment %}Example name: Varianti di dimensione {% endcomment %}
 {% capture example %}

--- a/src/scss/custom/_forms.scss
+++ b/src/scss/custom/_forms.scss
@@ -129,6 +129,7 @@ textarea {
   background-position: center right !important;
   background-repeat: no-repeat !important;
   background-size: 45px 45% !important;
+  border-radius: 0 !important;
   min-height: 2.5rem;
   &:disabled,
   &[readonly] {


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Aggiunte le classi `.form-control` a tutte le `<input>`.

Aggiunto il disclaimer sulla breaking change della v2.10.0 in merito alle varianti di dimensione `.form-control-lg` e `.form-control-sm`.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
