### PR TITLE
fix: link state in lists

### DIFF
--- a/docs/organizzare-i-contenuti/liste.md
+++ b/docs/organizzare-i-contenuti/liste.md
@@ -36,10 +36,10 @@ Gli elementi di tipo `<a>` dei collapse necessitano l'aggiunta dell'attributo `r
       </a>
     </li>
     <li>
-      <a class="list-item active" href="#">
-        <div class="it-right-zone"><span class="text">Link attivo</span>
+      <div class="list-item">
+        <div class="it-right-zone"><span class="text">Testo</span>
         </div>
-      </a>
+      </div>
     </li>
   </ul>
 </div>
@@ -68,7 +68,7 @@ L'elemento `.avatar` precede l'elemento `.it-right-zone` che contiene il testo.
       </a>
     </li>
     <li>
-      <a class="list-item active" href="#" >
+      <a class="list-item" href="#" >
         <div class="avatar size-lg"><img src="https://randomuser.me/api/portraits/women/41.jpg" alt="Anna Barbieri"></div>
         <div class="it-right-zone"><span class="text">Link attivo</span>
         </div>
@@ -105,7 +105,7 @@ L'elemento `.it-rounded-icon` con all'interno la relativa icona, precede l'eleme
       </a>
     </li>
     <li>
-      <a class="list-item active" href="#">
+      <a class="list-item" href="#">
         <div class="it-rounded-icon">
           <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-folder"></use></svg>
         </div>
@@ -140,7 +140,7 @@ L'elemento `.it-thumb` con all'interno la relativa immagine, precede l'elemento 
       </a>
     </li>
     <li>
-      <a class="list-item active" href="#">
+      <a class="list-item" href="#">
         <div class="it-thumb"><img src="https://via.placeholder.com/40x40.png?text=40x40" alt="descrizione immagine"></div>
         <div class="it-right-zone"><span class="text">Link attivo</span>
         </div>
@@ -229,19 +229,19 @@ L'elemento `.it-multiple` con all'interno le relative icone, segue l'elemento `.
       </div>
     </li>
     <li>
-      <div class="list-item active" href="#">
+      <div class="list-item" href="#">
         <div class="it-right-zone">
           <a href="#">
-            <span class="text">Link attivo</span>
+            <span class="text">Link</span>
           </a>
           <span class="it-multiple">
-            <a href="#" aria-label="Link attivo - Azione 1">
+            <a href="#" aria-label="Link - Azione 1">
               <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
-            <a href="#" aria-label="Link attivo - Azione 2">
+            <a href="#" aria-label="Link - Azione 2">
               <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
-            <a href="#" aria-label="Link attivo - Azione 3">
+            <a href="#" aria-label="Link - Azione 3">
               <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
           </span>
@@ -292,7 +292,7 @@ L'elemento `.metadata`, segue l'elemento `.text`.
       </div>
     </li>
     <li>
-      <a class="list-item active" href="#">
+      <a class="list-item" href="#">
         <div class="avatar size-lg"><img src="https://randomuser.me/api/portraits/women/41.jpg" alt="Anna Barbieri"></div>
         <div class="it-right-zone"><span class="text">Link attivo</span><span class="metadata">metadata testo</span>
         </div>
@@ -368,18 +368,18 @@ Per il testo aggiuntivo, utilizzare il tag `<em>` all'interno dell'elemento `.te
       </div>
     </li>
     <li>
-      <div class="list-item active">
+      <div class="list-item">
         <div class="it-right-zone">
-          <a href="#"><span class="text">Link attivo<em>Lorem ipsum dolor sit amet.</em></span></a>
+          <a href="#"><span class="text">Link<em>Lorem ipsum dolor sit amet.</em></span></a>
           <span class="it-multiple">
             <span class="metadata">metadata testo</span>
-            <a href="#" aria-label="Link attivo - Azione 1">
+            <a href="#" aria-label="Link - Azione 1">
               <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
-            <a href="#" aria-label="Link attivo - Azione 2">
+            <a href="#" aria-label="Link - Azione 2">
               <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
-            <a href="#" aria-label="Link attivo - Azione 3">
+            <a href="#" aria-label="Link - Azione 3">
               <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-code-circle"></use></svg>
             </a>
           </span>

--- a/src/scss/custom/_list.scss
+++ b/src/scss/custom/_list.scss
@@ -122,6 +122,10 @@
         }
       }
     }
+
+    a .text {
+      text-decoration: underline;
+    }
   }
 }
 

--- a/src/scss/custom/_list.scss
+++ b/src/scss/custom/_list.scss
@@ -4,6 +4,7 @@
     list-style-type: none;
     margin: 0;
     padding: 0;
+
     .list-item {
       transition: all 0.3s;
       margin-top: -1px;
@@ -12,87 +13,98 @@
       text-decoration: none;
       border-bottom: 1px solid $list-border-color;
       overflow-wrap: anywhere;
+
       .avatar,
       .it-rounded-icon,
       .it-thumb {
         flex-shrink: 0;
         margin-right: $v-gap * 2;
       }
+
       .it-rounded-icon {
         width: $v-gap * 5;
+
         svg {
           fill: $primary-a5;
         }
       }
+
       .form-check {
         margin-right: $v-gap;
         width: $v-gap;
         height: $v-gap * 4;
         text-align: left;
+
         & + .it-right-zone {
           margin-left: $v-gap * 2;
         }
+
         label {
           padding-left: 0;
           margin-bottom: 0;
         }
       }
+
       .it-thumb {
         width: $v-gap * 5;
         height: $v-gap * 5;
+
         img {
           object-fit: cover;
           width: 100%;
           height: 100%;
         }
       }
+
       .it-right-zone {
         padding: $list-text-padding;
         flex-grow: 1;
         display: flex;
         justify-content: space-between;
         align-items: center;
-        a {
-          text-decoration: none;
-        }
+
         svg {
           fill: $primary;
           width: $v-gap * 3;
           height: $v-gap * 3;
         }
+
         span.it-multiple {
           display: flex;
           justify-content: flex-end;
           flex-wrap: wrap;
+
           span.metadata {
             margin-right: 0;
             width: 100%;
             text-align: right;
           }
+
           svg {
             margin-left: $v-gap * 2;
             margin-right: 0;
           }
         }
+
         .toggles {
           height: $v-gap * 4;
         }
+
         span.metadata {
           color: $list-metadata-color;
           font-size: $list-metadata-size;
           letter-spacing: $list-metadata-space;
-          a {
-            color: $primary;
-          }
         }
       }
+
       span.text {
         font-size: $list-font-size;
         font-weight: 600;
-        display: block;
+
         @include media-breakpoint-up(lg) {
           font-size: 1.125rem;
         }
+
         em {
           display: block;
           font-size: $list-sub-size;
@@ -101,14 +113,8 @@
           font-weight: normal;
         }
       }
-      // active
-      &.active {
-        color: $color-text-base;
-        .text {
-          color: $color-text-base;
-        }
-      }
     }
+
     li:last-child {
       .list-item {
         span.text {
@@ -121,41 +127,41 @@
 
 //Desktop
 @include media-breakpoint-up(xl) {
+
   //mobile
   .it-list-wrapper {
     .it-list {
       .list-item {
+
         .avatar,
         .it-rounded-icon,
         .it-thumb {
           margin-left: $v-gap;
           margin-right: 0;
-          & + .it-right-zone {
+
+          &+.it-right-zone {
             margin-left: $v-gap * 2;
           }
         }
+
         .form-check {
           margin-right: $v-gap * 2;
           text-align: center;
         }
+
         // hover
         .it-right-zone {
           margin-left: $v-gap;
           margin-right: $v-gap;
-          a {
-            &:hover {
-              .text {
-                color: $primary;
-                text-decoration: underline;
-              }
-            }
-          }
+
           span.it-multiple {
             margin-right: $v-gap;
+
             a {
               svg {
-                transition: all 0.3s;
+                transition: fill 0.3s;
               }
+
               &:hover {
                 svg {
                   fill: $primary-a10;
@@ -163,33 +169,26 @@
               }
             }
           }
+
           .toggles {
             margin-right: 0;
           }
+
           span.metadata {
             margin-right: $v-gap;
-            a:hover {
-              text-decoration: underline;
-            }
           }
         }
       }
-      a {
-        &.list-item {
-          &:hover {
-            box-shadow: $card-shadow;
-            color: $color-text-primary-hover;
-            text-decoration: none;
-            background: $white;
-            position: relative;
-            z-index: 1;
-            transition: none;
-            border-bottom: 1px solid transparent;
-            span.text {
-              text-decoration: underline;
-            }
-          }
-        }
+
+      a.list-item:hover {
+        box-shadow: $card-shadow;
+        color: $color-text-primary-hover;
+        text-decoration: none;
+        background: $white;
+        position: relative;
+        z-index: 1;
+        transition: none;
+        border-bottom: 1px solid transparent;
       }
     }
   }


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

La proprietà `text-decoration: underline` viene applicata di default a tutti i link che fanno parte di liste semplici.

Rimosso lo stato `active` perché si tratta di liste che non appartengono a menu di navigazione (c'è un codice specifico per quelle). Pertanto è superfluo.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
