### PR TITLE
fix: replace padding with margin

### DIFF
--- a/src/scss/utilities/icons.scss
+++ b/src/scss/utilities/icons.scss
@@ -3,34 +3,34 @@
   height: 32px;
   vertical-align: middle;
   &.icon-padded {
-    padding: 8px;
+    margin: 8px;
   }
   &.icon-xs {
     width: 16px;
     height: 16px;
     &.icon-padded {
-      padding: 4px;
+      margin: 4px;
     }
   }
   &.icon-sm {
     width: 24px;
     height: 24px;
     &.icon-padded {
-      padding: 6px;
+      margin: 6px;
     }
   }
   &.icon-lg {
     width: 48px;
     height: 48px;
     &.icon-padded {
-      padding: 12px;
+      margin: 12px;
     }
   }
   &.icon-xl {
     width: 64px;
     height: 64px;
     &.icon-padded {
-      padding: 16px;
+      margin: 16px;
     }
   }
 }


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

Sostituisce `padding` con `margin` per correggere il bug per il quale la dimensione dell'icona con classe `.icon-padded` viene ridotta eccessivamente.

Risolve il bug #1315 

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
