### PR TITLE
fix: transform tabs filler from li to div

### DIFF
--- a/docs/componenti/tab.md
+++ b/docs/componenti/tab.md
@@ -703,7 +703,6 @@ Aggiungere la classe `.nav-tabs-cards` al tag `ul` per ottenere un design tipo c
   <li class="nav-item"><a class="nav-link" id="card-simple2-tab" data-bs-toggle="tab" href="#card-simpletab2" role="tab" aria-controls="card-simpletab2" aria-selected="false">Tab 2</a></li>
   <li class="nav-item"><a class="nav-link" id="card-simple3-tab" data-bs-toggle="tab" href="#card-simpletab3" role="tab" aria-controls="card-simpletab3" aria-selected="false">Tab 3</a></li>
   <li class="nav-item"><a class="nav-link disabled" id="card-simple4-tab" data-bs-toggle="tab" href="#card-simpletab4" role="tab" aria-controls="card-simpletab4" aria-selected="false" aria-disabled="true"  tabindex="-1">Tab 4 Disabilitato</a></li>
-  <div class="nav-item-filler"></div>
 </ul>
 <div class="tab-content" id="card-simpleContent">
   <div class="tab-pane p-4 fade show active" id="card-simpletab1" role="tabpanel" aria-labelledby="card-simple1-tab">Contenuto 1</div>
@@ -737,7 +736,6 @@ Aggiungere le classi `.nav-tabs-editable` e `.nav-tabs-cards` al tag `ul` per ot
         <a class="nav-link disabled" id="card-simple-btn4-tab" data-bs-toggle="tab" href="#card-simple-btntab4" role="tab" aria-controls="card-simple-btntab4" aria-selected="false" aria-disabled="true"  tabindex="-1">Tab 4 Disabilitato</a>
         <a class="nav-link-close disabled" href="#"><svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg><span class="visually-hidden"> Chiudi tab 4</span></a>
       </li>
-      <div class="nav-item-filler"></div>
       <li class="nav-item">
         <a class="nav-tab-add"><span class="visually-hidden"> Aggiungi un tab</span></a>
       </li>

--- a/docs/componenti/tab.md
+++ b/docs/componenti/tab.md
@@ -694,6 +694,13 @@ Per posizionare i tab verticali a destra contenuto è necessario applicare la cl
 
 ## Tab tipo Card
 
+{% capture callout %}
+Breaking feature dalla versione **2.13.0**
+
+Sono stati rimossi gli elementi delle liste con classe `nav-item-filler` per 
+tutte le tab di tipo `Card`.
+{% endcapture %}{% include callout.html content=callout type="danger" %}
+
 Aggiungere la classe `.nav-tabs-cards` al tag `ul` per ottenere un design tipo card.
 
 {% comment %}Example name: Con controllo pannelli, tipo card{% endcomment %}

--- a/docs/componenti/tab.md
+++ b/docs/componenti/tab.md
@@ -703,7 +703,7 @@ Aggiungere la classe `.nav-tabs-cards` al tag `ul` per ottenere un design tipo c
   <li class="nav-item"><a class="nav-link" id="card-simple2-tab" data-bs-toggle="tab" href="#card-simpletab2" role="tab" aria-controls="card-simpletab2" aria-selected="false">Tab 2</a></li>
   <li class="nav-item"><a class="nav-link" id="card-simple3-tab" data-bs-toggle="tab" href="#card-simpletab3" role="tab" aria-controls="card-simpletab3" aria-selected="false">Tab 3</a></li>
   <li class="nav-item"><a class="nav-link disabled" id="card-simple4-tab" data-bs-toggle="tab" href="#card-simpletab4" role="tab" aria-controls="card-simpletab4" aria-selected="false" aria-disabled="true"  tabindex="-1">Tab 4 Disabilitato</a></li>
-  <li class="nav-item-filler"></li>
+  <div class="nav-item-filler"></div>
 </ul>
 <div class="tab-content" id="card-simpleContent">
   <div class="tab-pane p-4 fade show active" id="card-simpletab1" role="tabpanel" aria-labelledby="card-simple1-tab">Contenuto 1</div>
@@ -737,7 +737,7 @@ Aggiungere le classi `.nav-tabs-editable` e `.nav-tabs-cards` al tag `ul` per ot
         <a class="nav-link disabled" id="card-simple-btn4-tab" data-bs-toggle="tab" href="#card-simple-btntab4" role="tab" aria-controls="card-simple-btntab4" aria-selected="false" aria-disabled="true"  tabindex="-1">Tab 4 Disabilitato</a>
         <a class="nav-link-close disabled" href="#"><svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-close"></use></svg><span class="visually-hidden"> Chiudi tab 4</span></a>
       </li>
-      <li class="nav-item-filler"></li>
+      <div class="nav-item-filler"></div>
       <li class="nav-item">
         <a class="nav-tab-add"><span class="visually-hidden"> Aggiungi un tab</span></a>
       </li>

--- a/src/scss/components/_tab.scss
+++ b/src/scss/components/_tab.scss
@@ -210,9 +210,8 @@
     border-bottom: none;
 
     //grey fullwidth bottom border for ul
-    &::after
-    {
-      content:'';
+    &::after {
+      content: '';
       flex-grow: 1;
       border-bottom: 1px solid $color-border-subtle;
     }

--- a/src/scss/components/_tab.scss
+++ b/src/scss/components/_tab.scss
@@ -210,7 +210,9 @@
     border-bottom: none;
 
     //grey fullwidth bottom border for ul
-    .nav-item-filler {
+    &::after
+    {
+      content:'';
       flex-grow: 1;
       border-bottom: 1px solid $color-border-subtle;
     }
@@ -235,11 +237,6 @@
       &:last-of-type {
         border-bottom: 1px solid $color-border-subtle;
       }
-    }
-
-    //grey fullwidth bottom border for ul
-    .nav-item-filler {
-      width: 2em;
     }
 
     //add button

--- a/src/scss/components/_tab.scss
+++ b/src/scss/components/_tab.scss
@@ -246,7 +246,7 @@
       width: 1.444rem;
       height: 1.444rem;
       top: 0.8rem;
-      border: 1px solid $color-border-subtle;
+      border: 1px solid $primary;
       border-radius: 50%;
       right: 0;
       //plus sign


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

Fixes #1325 

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
