### PR TITLE
fix: typo in introduzione

### DIFF
--- a/docs/come-iniziare/introduzione.md
+++ b/docs/come-iniziare/introduzione.md
@@ -490,7 +490,7 @@ Per caricare i font utilizzando JavaScript occorre chiamare **esplicitamente** l
 {% endcapture %}{% include callout-breaking.html version="2.2.0" content=callout type="danger" %}
 
 {% capture callout %}
-Il `focus` con la tastiera viene adesso settato con l'attributo `datadata-focus-mouse`
+Il `focus` con la tastiera viene adesso settato con l'attributo `data-focus-mouse`
 invece che con la classe `focus--mouse`. Da tenere presente nel caso di un 
 precedente utilizzo della classe `focus--mouse` per un controllo e/o un' implementazione 
 ulteriore di accessibilità. 


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Corretto un typo nella documentazione della breaking change relativa al focus.

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
