### PR TITLE
fix: carousel typo

### DIFF
--- a/src/scss/base/_variables.scss
+++ b/src/scss/base/_variables.scss
@@ -1952,8 +1952,8 @@ $crs-dots-margin-left: 38px;
 $crs-dots-margin-left-desk: $v-gap * 2;
 $crs-heading-h-padding: $v-gap * 3;
 $crs-heading-h-size: 1.75rem;
-$crs-landcape-card-padding: $v-gap * 6;
-$crs-landcape-bottom: 5px;
+$crs-landcape-card-padding: $v-gap * 6; // Variabile non usata
+$crs-landscape-bottom: 5px;
 
 // Gridlist **************
 $grid-item-df-proportion: 66.81222707423581%;

--- a/src/scss/components/_carousel.scss
+++ b/src/scss/components/_carousel.scss
@@ -202,7 +202,7 @@
         left: 50%;
         margin-left: $v-gap * 5;
         right: 0;
-        bottom: $crs-landcape-bottom;
+        bottom: $crs-landscape-bottom;
         text-align: left;
         justify-content: left;
         margin-bottom: 8px;


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

Ho corretto un errore di battitura nel nome della variabile `$crs-landcape-bottom` in `$crs-landscape-bottom` sia nel file dove definita che dove viene usata. Inoltre ho aggiunto un commento alla variabile `$crs-landcape-card-padding` per identificarla come variabile non usata

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
