### PR TITLE
chore: refactor focus mixin

### DIFF
--- a/src/scss/base/_mixins.scss
+++ b/src/scss/base/_mixins.scss
@@ -20,6 +20,7 @@
 
 // Utilities
 @import 'mixins/utilities';
+@import 'mixins/focus';
 
 // Components
 @import 'mixins/alert';

--- a/src/scss/base/mixins/_focus.scss
+++ b/src/scss/base/mixins/_focus.scss
@@ -1,0 +1,14 @@
+%focus{
+  border-color: $focus-outline-color-out !important;
+  box-shadow:
+    0 0 0 2px var(--#{$prefix}color-border-inverse),
+    0 0 0 5px var(--#{$prefix}color-outline-focus) !important;
+  outline: 3px solid transparent !important;
+  outline-offset: 3px !important;
+}
+
+%focusmouse {
+  border-color: inherit !important;
+  box-shadow: none !important;
+  outline: none !important;
+}

--- a/src/scss/bootstrap-italia.scss
+++ b/src/scss/bootstrap-italia.scss
@@ -17,6 +17,7 @@
 
 // Functions, maps and mixins
 @import 'base/mixins';
+@import 'base/mixins/focus';
 @import 'base/maps';
 @import 'base/utilities';
 // ------------------------------

--- a/src/scss/utilities/focus.scss
+++ b/src/scss/utilities/focus.scss
@@ -1,27 +1,18 @@
 :focus:not([data-focus-mouse='true']),
-%focus,
 .it-carousel-wrapper .splide__pagination button:focus:not([data-focus-mouse='true']),
 .upload:focus:not([data-focus-mouse='true']) + label,
 .upload-dragdrop-input:focus[type='file']:not([data-focus-mouse='true']) + label,
 .avatar-upload:focus-within:not([data-focus-mouse='true']),
 .rating input:focus:not([data-focus-mouse='true']) + label svg {
-  border-color: $focus-outline-color-out !important;
-  box-shadow:
-    0 0 0 2px var(--#{$prefix}color-border-inverse),
-    0 0 0 5px var(--#{$prefix}color-outline-focus) !important;
-  outline: 3px solid transparent !important;
-  outline-offset: 3px !important;
+  @extend %focus;
 }
 
 [tabindex='-1']:focus:not(:focus-visible) {
   box-shadow: none !important;
 }
 
-[data-focus-mouse='true']:not(.btn),
-%focusmouse {
-  border-color: inherit !important;
-  box-shadow: none !important;
-  outline: none !important;
+[data-focus-mouse='true']:not(.btn) {
+  @extend %focusmouse;
 }
 
 p a {


### PR DESCRIPTION
## Descrizione

spostati i mixin del focus in un file dedicato, in modo che possano essere importabili e riutilizzabili senza per forza dover importare il file focus.scss che nell'integrazione con i web-components genererebbe problemi di focus. 