### PR TITLE
fix: disabled toggles in fieldset

### DIFF
--- a/src/scss/forms/_form-toggles.scss
+++ b/src/scss/forms/_form-toggles.scss
@@ -85,6 +85,7 @@
       }
     }
 
+    [disabled] & + .lever,
     &[disabled] + .lever {
       cursor: default;
       background-color: #e6e9f2;
@@ -93,6 +94,7 @@
       }
     }
 
+    [disabled] &:checked + .lever:after,
     &[disabled]:checked + .lever:after {
       background-color: #e6e9f2;
     }


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Corregger il bug per cui se un `fieldset` ha l'attributo `disabled` i toggles rimanevano visivamente attivi.

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
