### PR TITLE
fix: docs sidebar active links

### DIFF
--- a/_includes/docs-sidebar.html
+++ b/_includes/docs-sidebar.html
@@ -11,7 +11,7 @@
           'active' -%} {%- assign expanded = 'true' -%} {%- endif -%}
           <li>
             {% if group.pages == nil %}
-            <a class="list-item active" href="{{ site.baseurl }}/docs/{{ group_slug }}/"><span>{{ group.title }}</span></a>
+            <a class="list-item{% if page.group == group_slug %} active{% endif %}" href="{{ site.baseurl }}/docs/{{ group_slug }}{% unless group_slug == '' %}/{% endunless %}"><span>{{ group.title }}</span></a>
             {% else %}
             <!-- One:usare ID -->
             <a
@@ -31,10 +31,10 @@
               </span>
             </a>
             <ul class="link-sublist collapse {% unless active == nil %}show{% endunless %}" id="collapse-{{ forloop.index }}">
-              {%- for doc in group.pages -%} {%- assign doc_slug = doc.title | slugify -%} {%- assign active = nil -%} {%- if page.group == group_slug and
-              page_slug == doc_slug -%} {%- assign active = 'active' -%} {%- endif -%}
+              {%- for doc in group.pages -%} {%- assign doc_slug = doc.title | slugify -%} {%- assign sub_active = nil -%} {%- if page.group == group_slug and
+              page_slug == doc_slug -%} {%- assign sub_active = 'active' -%} {%- endif -%}
               <li>
-                <a class="list-item {% unless active == nil %} {{ active }}{% endunless %}" href="{{ site.baseurl }}/docs/{{ group_slug }}/{{ doc_slug }}/">
+                <a class="list-item {% unless sub_active == nil %} {{ sub_active }}{% endunless %}" href="{{ site.baseurl }}/docs/{{ group_slug }}/{{ doc_slug }}/">
                   <span>{{ doc.title }}</span>
                   {%- if doc.status %}<span class="badge bg-secondary text-white">{{ doc.status }}</span>{%- endif -%}
                 </a>

--- a/docs/breaking-change.md
+++ b/docs/breaking-change.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-group: breking-feature
+group: breaking-change
 toc: true
 title: Breaking change
 redirect_from: '/breaking-change/'


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Corregge l'assegnazione della classe `.active` sui link non appartenenti ad alcun gruppo.

Corregge un errore dell'attributo `group` per la pagina breaking change.

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
