### PR TITLE
fix: vite failing to import splide's scss

### DIFF
--- a/src/scss/components/_carousel.scss
+++ b/src/scss/components/_carousel.scss
@@ -1,4 +1,4 @@
-@import '@splidejs/splide/src/css/core/index';
+@import '@splidejs/splide/dist/css/splide-core.min';
 
 // Keep all .card-SOMETHING till next major? (.card is deprecated)
 


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->
## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->
Come si può vedere [qui](https://github.com/italia/design-react-kit/issues/1202), ho provato a customizzare l'scss in un progetto che usa `vite` e `design-react-kit`. Sembra che `vite` non riesca a importare i sorgenti scss di `splide` perché non sono presenti tra gli export del loro package.json.  
Quella libreria sembra non essere mantenuta da circa tre anni quindi non so se valga la pena di aprire loro una PR, ma comunque ho visto che nel file `_carousel.scss` non viene fatto nessun override di variabili e funzioni di splide, quindi penso si possa tranquillamente importare direttamente il css e la documentazione sembra venga renderizzata correttamente.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
