### PR TITLE
fix(docs): path errato nel bottone per copiare il codice

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -166,7 +166,7 @@ https://github.com/algolia/docsearch{% endcomment %}
             const originalHTML = button.innerHTML;
             const originalAriaLabel = button.getAttribute('aria-label');
 
-            button.innerHTML = '<svg role="img" class="icon icon-sm align-middle icon-white" aria-label="Copiato"><use href="/dist/svg/sprites.svg#it-check"></use></svg>';
+            button.innerHTML = '<svg role="img" class="icon icon-sm align-middle icon-white" aria-label="Copiato"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check"></use></svg>';
             button.setAttribute('aria-label', 'Codice copiato negli appunti');
             button.classList.remove('btn-secondary');
             button.classList.add('btn-success');
@@ -203,7 +203,7 @@ https://github.com/algolia/docsearch{% endcomment %}
         divContainer.classList.add('copy-button-container');
         button.type = 'button';
         button.setAttribute('aria-label', 'Copia il codice negli appunti');
-        button.innerHTML = '<svg role="img" class="icon icon-sm align-middle icon-white" aria-label="Copia"><use href="/dist/svg/sprites.svg#it-copy"></use></svg>';
+        button.innerHTML = '<svg role="img" class="icon icon-sm align-middle icon-white" aria-label="Copia"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-copy"></use></svg>';
         button.classList.add('btn', 'btn-primary', 'btn-xs', 'btn-secondary');
 
         button.addEventListener('click', function () {
@@ -218,7 +218,7 @@ https://github.com/algolia/docsearch{% endcomment %}
             const originalHTML = button.innerHTML;
             const originalAriaLabel = button.getAttribute('aria-label');
 
-            button.innerHTML = '<svg role="img" class="icon icon-sm align-middle icon-white" aria-label="Copiato"><use href="/dist/svg/sprites.svg#it-check"></use></svg>';
+            button.innerHTML = '<svg role="img" class="icon icon-sm align-middle icon-white" aria-label="Copiato"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check"></use></svg>';
             button.setAttribute('aria-label', 'Codice copiato negli appunti');
             button.classList.remove('btn-secondary');
             button.classList.add('btn-success');


### PR DESCRIPTION
Dopo l'ultimo aggiornamento il bottone per copiare il codice non visualizza correttamente l'icona a causa di un path errato.

Esempio: https://italia.github.io/bootstrap-italia/docs/come-iniziare/introduzione/

<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

Ho aggiunto `{{ site.baseurl }}`.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [X] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [X] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [X] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [X] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
