### PR TITLE
fix: numberinput validation styles and readonly styles

### DIFF
--- a/docs/esempi/form/index.html
+++ b/docs/esempi/form/index.html
@@ -26,13 +26,33 @@ title: Validazione Form
       <div class="col-12 col-md-4">
         <div class="form-group">
           <label for="age">Campo numerico (min/max)</label>
-          <input type="number" data-bs-input class="form-control" id="age" min="18" max="50" step="1" required />
+          <span class="input-group input-number">
+            <input type="number" data-bs-input class="form-control" id="age" min="18" max="50" step="1" required />
+            <span class="input-group-text align-buttons flex-column">
+                <button class="input-number-add">
+                  <span class="visually-hidden">Aumenta valore Euro</span>
+                </button>
+                <button class="input-number-sub">
+                  <span class="visually-hidden">Diminuisci valore Euro</span>
+                </button>
+            </span>
+          </span>
         </div>
       </div>
       <div class="col-12 col-md-4">
         <div class="form-group">
           <label for="camponumerico">Campo numerico (5 cifre)</label>
-          <input type="number" data-bs-input class="form-control" id="camponumerico" maxlenght="5" required />
+          <span class="input-group input-number">
+            <input type="number" data-bs-input class="form-control" id="camponumerico" maxlenght="5" required />
+            <span class="input-group-text align-buttons flex-column">
+                <button class="input-number-add">
+                  <span class="visually-hidden">Aumenta valore Euro</span>
+                </button>
+                <button class="input-number-sub">
+                  <span class="visually-hidden">Diminuisci valore Euro</span>
+                </button>
+            </span>
+          </span>
         </div>
       </div>
     </div>
@@ -162,7 +182,7 @@ title: Validazione Form
         </div>
       </div>
 
-        
+
     </div>
 
     <div class="row mb-4">

--- a/src/scss/forms/_form-control.scss
+++ b/src/scss/forms/_form-control.scss
@@ -4,7 +4,6 @@
 
 @import '../base/mixins';
 
-
 // Readonly controls as plain text
 //
 // Apply class to a readonly input to make it appear like regular plain
@@ -21,7 +20,7 @@
     outline: 0;
     box-shadow: none !important;
   }
-  
+
   & + label {
     cursor: text;
   }
@@ -51,22 +50,16 @@
     border-color: var(--#{$prefix}color-border-danger);
   }
 
-  // Change background size for number inputs
-  .was-validated &:invalid[type='number'],
-  &.is-invalid[type='number']{
-    background-size: 80px 30%;
-  }
-
   &.warning {
-    background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%0A%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M2%2012C2%206.47715%206.47715%202%2012%202C14.6522%202%2017.1957%203.05357%2019.0711%204.92893C20.9464%206.8043%2022%209.34784%2022%2012C22%2017.5228%2017.5228%2022%2012%2022C6.47715%2022%202%2017.5228%202%2012ZM3%2012C3%2016.9706%207.02944%2021%2012%2021C16.9706%2021%2021%2016.9706%2021%2012C21%207.02944%2016.9706%203%2012%203C7.02944%203%203%207.02944%203%2012ZM11.5%2014.2V5.7H12.7V14.2H11.5ZM12.6%2018.3V16.5H11.4V18.3H12.6Z%22/%3E%0A%3C/svg%3E") no-repeat;
+    background-image: url('data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%0A%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M2%2012C2%206.47715%206.47715%202%2012%202C14.6522%202%2017.1957%203.05357%2019.0711%204.92893C20.9464%206.8043%2022%209.34784%2022%2012C22%2017.5228%2017.5228%2022%2012%2022C6.47715%2022%202%2017.5228%202%2012ZM3%2012C3%2016.9706%207.02944%2021%2012%2021C16.9706%2021%2021%2016.9706%2021%2012C21%207.02944%2016.9706%203%2012%203C7.02944%203%203%207.02944%203%2012ZM11.5%2014.2V5.7H12.7V14.2H11.5ZM12.6%2018.3V16.5H11.4V18.3H12.6Z%22/%3E%0A%3C/svg%3E')
+      no-repeat;
     border-color: var(--#{$prefix}color-border-warning);
   }
 
-  &.is-valid~.warning-feedback {
+  &.is-valid ~ .warning-feedback {
     display: block;
   }
 }
-
 
 // Form control sizing
 //

--- a/src/scss/forms/_form-input-number.scss
+++ b/src/scss/forms/_form-input-number.scss
@@ -1,7 +1,6 @@
 .input-number {
   position: relative;
 
-
   &.input-number-adaptive {
     width: fit-content;
     input[type='number'] {
@@ -13,7 +12,9 @@
   //reset input style
   input[type='number'] {
     appearance: textfield;
-    border-right: 0;
+    // border-right: 0;
+    border-top-right-radius: var(--bs-form-control-border-radius) !important;
+    border-bottom-right-radius: var(--bs-form-control-border-radius) !important;
 
     &::-webkit-inner-spin-button,
     &::-webkit-outer-spin-button {
@@ -41,11 +42,19 @@
 
   //add + sub buttons
   .input-group-text.align-buttons {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    z-index: 10;
+
     padding-right: var(--#{$prefix}form-control-spacing);
-    border-left: 0;
-    border-right-width: 1px;
+    // border-left: 0;
+    // border-right-width: 1px;
+    border: none;
+    background: transparent;
   }
- 
+
   .input-group-text button {
     position: relative;
     transition: opacity 0.1s;
@@ -102,7 +111,7 @@
 // Reset border when input is prepended with input-group-text
 input[type='number'] {
   .input-number .input-group-text + & {
-    border-left: 0;   
+    border-left: 0;
   }
 }
 

--- a/src/scss/forms/_form-input-number.scss
+++ b/src/scss/forms/_form-input-number.scss
@@ -28,11 +28,19 @@
     &:not(:disabled) {
       border-left: 1px solid var(--#{$prefix}form-control-border-color);
     }
+
+    &[readonly] ~ .input-group-text {
+      .input-number-add,
+      .input-number-sub {
+        display: none;
+      }
+    }
   }
 
   //disabled version
   &.disabled {
     button {
+      display: none;
       pointer-events: none;
       &:hover {
         cursor: not-allowed;


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

sistemati gli stili durante la validazione dei campi di tipo number input
e lo stato readonly dei campi di tipo number input


## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
