### PR TITLE
refactor(buttons): integrate outline border definition into existing theme-color loop

### DIFF
--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -155,6 +155,12 @@
 @each $color, $value in $theme-colors {
   .btn-outline-#{$color} {
     @include button-outline-variant($value);
+    box-shadow: inset 0 0 0 2px $value;
+    &.disabled,
+    &:hover,
+    &:active {
+      box-shadow: inset 0 0 0 2px color-hover($value);
+    }
   }
 }
 // scss-docs-end btn-variant-loops
@@ -344,47 +350,6 @@
       background-color: hsl(210, 12%, 52%); // UI kit - missing tokens
       border-color: hsl(210, 12%, 52%); // UI kit - missing tokens
       opacity: 1;
-    }
-  }
-}
-
-.btn-outline {
-  &-primary {
-    box-shadow: inset 0 0 0 2px $primary;
-    &.disabled {
-      box-shadow: inset 0 0 0 2px color-hover($primary);
-    }
-  }
-  &-secondary {
-    box-shadow: inset 0 0 0 2px $secondary;
-    &.disabled,
-    &:hover,
-    &:active {
-      box-shadow: inset 0 0 0 2px color-hover($secondary);
-    }
-  }
-  &-success {
-    box-shadow: inset 0 0 0 2px $success;
-    &.disabled,
-    &:hover,
-    &:active {
-      box-shadow: inset 0 0 0 2px color-hover($success);
-    }
-  }
-  &-warning {
-    box-shadow: inset 0 0 0 2px $color-border-warning;
-    &.disabled,
-    &:hover,
-    &:active {
-      box-shadow: inset 0 0 0 2px color-hover($color-border-warning);
-    }
-  }
-  &-danger {
-    box-shadow: inset 0 0 0 2px $danger;
-    &.disabled,
-    &:hover,
-    &:active {
-      box-shadow: inset 0 0 0 2px color-hover($danger);
     }
   }
 }


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

I bordi dei pulsanti con variante outline erano precedentemente definiti separatamente per un insieme limitato di colori del tema. Questa modifica integra la definizione dei bordi direttamente nel ciclo SCSS esistente sulla mappa $theme-color, garantendo uno stile coerente per tutte le varianti outline.

Fixes #1569 

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
