### PR TITLE
fix: image background on `d-flex` containers

### DIFF
--- a/docs/assets/src/scss/_component-examples.scss
+++ b/docs/assets/src/scss/_component-examples.scss
@@ -10,9 +10,6 @@
       0 10px,
       10px -10px,
       -10px 0px;
-  }
-
-  .row {
     > .col,
     > [class^='col-'] {
       padding-top: 0.75rem;


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Corregge un bug per cui gli elementi accordion `Codice Bootstrap Italia` mostrano immagine di sfondo/

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
