### PR TITLE
fix(3.x): form check formtext

### DIFF
--- a/src/scss/forms/_forms.scss
+++ b/src/scss/forms/_forms.scss
@@ -326,12 +326,6 @@ input::-webkit-datetime-edit {
     &:focus[data-focus-mouse='true'] + label {
       @extend %focusmouse;
     }
-
-    .form-text {
-      display: block;
-      margin-bottom: 0.5rem;
-      padding-right: 3.25rem;
-    }
   }
 
   input[type='checkbox'] {
@@ -476,6 +470,12 @@ input::-webkit-datetime-edit {
     }
   }
 
+  .form-text {
+    display: block;
+    margin-bottom: 0.5rem;
+    padding-right: 3.25rem;
+  }
+
   //
   // Checkbox group
 
@@ -483,10 +483,6 @@ input::-webkit-datetime-edit {
     margin-bottom: 1rem;
     padding: 0 0 1rem 0;
     box-shadow: inset 0 -1px 0 0 rgba(1, 1, 1, 0.1);
-
-    .form-text {
-      display: block;
-    }
 
     input[type='checkbox'] + label,
     input[type='radio'] + label {


### PR DESCRIPTION
gli elementi "testo di supporto" venivano mostrati affiancati alla label della checkbox anzichè sotto alla label, in quanto la regola css era definita sola per form-check-group e non per form-check

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
