### PR TITLE
fix: remove eval from cover animation

### DIFF
--- a/docs/assets/src/js/cover-animation.js
+++ b/docs/assets/src/js/cover-animation.js
@@ -10077,8 +10077,9 @@
   AdobeAn.Layer = new (function () {
     this.getLayerZDepth = function (timeline, layerName) {
       if (layerName === 'Camera') layerName = '___camera___instance'
-      var script = 'if(timeline.' + layerName + ') timeline.' + layerName + '.depth; else 0;'
-      return eval(script)
+      var target = timeline[layerName]
+      if (target) return target.depth
+      return 0
     }
     this.setLayerZDepth = function (timeline, layerName, zDepth) {
       var MAX_zDepth = 10000
@@ -10086,13 +10087,17 @@
       if (zDepth > MAX_zDepth) zDepth = MAX_zDepth
       else if (zDepth < MIN_zDepth) zDepth = MIN_zDepth
       if (layerName === 'Camera') layerName = '___camera___instance'
-      var script = 'if(timeline.' + layerName + ') timeline.' + layerName + '.depth = ' + zDepth + ';'
-      eval(script)
+      var target = timeline[layerName]
+      if (target) {
+        target.depth = zDepth
+      }
     }
     this.removeLayer = function (timeline, layerName) {
       if (layerName === 'Camera') layerName = '___camera___instance'
-      var script = 'if(timeline.' + layerName + ') timeline.removeChild(timeline.' + layerName + ');'
-      eval(script)
+      var target = timeline[layerName]
+      if (target) {
+        timeline.removeChild(target)
+      }
     }
     this.addNewLayer = function (timeline, layerName, zDepth) {
       if (layerName === 'Camera') layerName = '___camera___instance'


### PR DESCRIPTION
## Summary

This PR removes the usage of `eval` from `docs/assets/src/js/cover-animation.js`, replacing it with direct property access on `timeline` to comply with stricter Content Security Policy (CSP) configurations.

## Details

- `AdobeAn.Layer.getLayerZDepth` now accesses the layer instance via `timeline[layerName]` and returns its `depth` (or `0` if the layer is missing), instead of evaluating a generated script string.
- `AdobeAn.Layer.setLayerZDepth` keeps the existing clamping logic for `zDepth` and assigns `target.depth` directly when the layer exists, without using `eval`.
- `AdobeAn.Layer.removeLayer` now calls `timeline.removeChild(target)` directly if the layer instance is present.
- The special case `layerName === 'Camera'` is preserved and still mapped to `'___camera___instance'`.

This change preserves the public `AdobeAn.Layer` API while avoiding string evaluation, improving compatibility with CSP settings that disallow `eval`.

---

marioprotoBot