### PR TITLE
Fix: ripristina semantica liste su Safari/VO (`BI2`): style `li::marker`

### DIFF
--- a/src/scss/components/_avatar.scss
+++ b/src/scss/components/_avatar.scss
@@ -463,7 +463,9 @@ a.avatar {
   padding: 0;
   flex-direction: row;
   li {
-    list-style-type: none;
+    &::marker {
+      font-size: 0; // hide default marker safely without affecting Safari accessibility
+    }
     line-height: 0;
     & > .avatar {
       margin-left: -6px;

--- a/src/scss/components/_bottomnav.scss
+++ b/src/scss/components/_bottomnav.scss
@@ -35,7 +35,9 @@
     margin: 0;
     height: 64px;
     li {
-      list-style-type: none;
+      &::marker {
+        font-size: 0; // hide default marker safely without affecting Safari accessibility
+      }
       margin: 8px;
       text-align: center;
     }

--- a/src/scss/components/_card.scss
+++ b/src/scss/components/_card.scss
@@ -1,8 +1,13 @@
 // Special list for long groups of cards, bootstrap row/cols grid
 ul.row.it-card-list {
-  list-style-type: none;
   margin: 0;
   padding: 0;
+
+  li {
+    &::marker {
+      font-size: 0; // hide default marker safely without affecting Safari accessibility
+    }
+  }
 
   > li.col,
   > li[class*='col-'] {
@@ -378,6 +383,12 @@ article.it-card {
       display: flex;
       flex-wrap: wrap;
 
+      li {
+          &::marker {
+          font-size: 0; // hide default marker safely without affecting Safari accessibility
+        }
+      }
+
       // Gap fallback
       > li {
         margin: 0.25rem;
@@ -394,7 +405,6 @@ article.it-card {
       padding: 0;
       margin-top: 0.5rem;
       margin-bottom: 0;
-      list-style-type: none;
       line-height: 1.5;
     }
 

--- a/src/scss/components/_card.scss
+++ b/src/scss/components/_card.scss
@@ -384,7 +384,7 @@ article.it-card {
       flex-wrap: wrap;
 
       li {
-          &::marker {
+        &::marker {
           font-size: 0; // hide default marker safely without affecting Safari accessibility
         }
       }

--- a/src/scss/components/_headercenter.scss
+++ b/src/scss/components/_headercenter.scss
@@ -60,7 +60,11 @@
         align-items: center;
         font-size: $header-center-text-size;
         ul {
-          list-style-type: none;
+          li {
+            &::marker {
+              font-size: 0; // hide default marker safely without affecting Safari accessibility
+            }
+          }
           margin: 0;
           padding: 0;
           display: flex;
@@ -167,7 +171,11 @@
           align-items: center;
           font-size: $header-center-text-size;
           ul {
-            list-style-type: none;
+            li {
+              &::marker {
+                font-size: 0; // hide default marker safely without affecting Safari accessibility
+              }
+            }
             margin: 0;
             padding: 0;
             display: flex;

--- a/src/scss/components/_linklist.scss
+++ b/src/scss/components/_linklist.scss
@@ -32,12 +32,14 @@
   }
   ul {
     padding: 0;
-    list-style-type: none;
     // sottolista
     &.link-sublist {
       padding-left: $link-list-h-pad;
     }
     li {
+      &::marker {
+        font-size: 0; // hide default marker safely without affecting Safari accessibility
+      }
       a {
         font-size: $link-list-font-size;
         line-height: $link-list-line-height;

--- a/src/scss/components/_list-group.scss
+++ b/src/scss/components/_list-group.scss
@@ -33,8 +33,13 @@
 }
 
 .list-group-numbered {
-  list-style-type: none;
   counter-reset: section;
+
+  li {
+    &::marker {
+      font-size: 0; // hide default marker safely without affecting Safari accessibility
+    }
+  }
 
   > .list-group-item::before {
     // Increments only this instance of the section counter

--- a/src/scss/components/_list.scss
+++ b/src/scss/components/_list.scss
@@ -1,7 +1,6 @@
 //mobile
 .it-list-wrapper {
   .it-list {
-    list-style-type: none;
     margin: 0;
     padding: 0;
 
@@ -112,10 +111,16 @@
       }
     }
 
-    li:last-child {
-      .list-item {
-        span.text {
-          border-bottom: 1px solid transparent;
+    li {
+      &::marker {
+        font-size: 0; // hide default marker safely without affecting Safari accessibility
+      }
+
+      &:last-child {
+        .list-item {
+          span.text {
+            border-bottom: 1px solid transparent;
+          }
         }
       }
     }

--- a/src/scss/components/_steppers.scss
+++ b/src/scss/components/_steppers.scss
@@ -41,7 +41,9 @@
         font-size: 1.125rem;
         font-weight: 600;
         color: $gray-secondary;
-        list-style-type: none;
+        &::marker {
+          font-size: 0; // hide default marker safely without affecting Safari accessibility
+        }
         .icon {
           fill: $gray-secondary;
           margin-right: 0.667rem;
@@ -156,7 +158,9 @@
       justify-content: center;
       align-items: center;
       li {
-        list-style-type: none;
+        &::marker {
+          font-size: 0; // hide default marker safely without affecting Safari accessibility
+        }
         padding: 0;
         height: 4px;
         width: 4px;

--- a/src/scss/components/_thumbnav.scss
+++ b/src/scss/components/_thumbnav.scss
@@ -130,8 +130,10 @@
 
   // list element
   li {
+    &::marker {
+      font-size: 0; // hide default marker safely without affecting Safari accessibility
+    }
     position: relative;
-    list-style-type: none;
     margin: 8px;
     width: 240px;
     flex: 0 1 auto;

--- a/src/scss/components/_toolbar.scss
+++ b/src/scss/components/_toolbar.scss
@@ -241,7 +241,7 @@
     height: 64px;
     & > li {
       &::marker {
-       font-size: 0; // hide default marker safely without affecting Safari accessibility
+        font-size: 0; // hide default marker safely without affecting Safari accessibility
       }
       margin: 0 8px;
       text-align: center;

--- a/src/scss/components/_toolbar.scss
+++ b/src/scss/components/_toolbar.scss
@@ -240,7 +240,9 @@
     margin: 0;
     height: 64px;
     & > li {
-      list-style-type: none;
+      &::marker {
+       font-size: 0; // hide default marker safely without affecting Safari accessibility
+      }
       margin: 0 8px;
       text-align: center;
       // divider

--- a/src/scss/forms/_autocomplete.scss
+++ b/src/scss/forms/_autocomplete.scss
@@ -48,7 +48,9 @@
   }
 
   li {
-    list-style-type: none;
+    &::marker {
+     font-size: 0; // hide default marker safely without affecting Safari accessibility
+    }
     padding: 0;
   }
 

--- a/src/scss/forms/_autocomplete.scss
+++ b/src/scss/forms/_autocomplete.scss
@@ -49,7 +49,7 @@
 
   li {
     &::marker {
-     font-size: 0; // hide default marker safely without affecting Safari accessibility
+      font-size: 0; // hide default marker safely without affecting Safari accessibility
     }
     padding: 0;
   }

--- a/src/scss/forms/_form-input-upload.scss
+++ b/src/scss/forms/_form-input-upload.scss
@@ -46,7 +46,9 @@
   flex-wrap: wrap;
   //grid list element
   & > li {
-    list-style-type: none;
+    &::marker {
+      font-size: 0; // hide default marker safely without affecting Safari accessibility
+    }
     margin-right: $v-gap;
     margin-bottom: $v-gap;
 
@@ -120,7 +122,9 @@
   }
 
   .upload-file {
-    list-style-type: none;
+    &::marker {
+      font-size: 0; // hide default marker safely without affecting Safari accessibility
+    }
     display: flex;
     align-items: center;
     max-width: 375px;


### PR DESCRIPTION
## Cosa
FIx #1692 (alternativa alla PR #1751)

Questa PR implementa la soluzione proposta da @deodorhunter (`font-size: 0` sul `li::marker`, rimuovendo `list-style-type: none`) per quanto riguarda **BSI v2.** 

Dobbiamo fare review con calma in tutte le combinazioni di OS/Browser/SR sia **dei componenti i cui scss sono stati toccati direttamente** (vedi tab "Files changed", sia dei componenti che usano le liste (Dropdown, Megamenu, Navscroll, Modale, Paginazione, Sticky, Footer e Sidebar mi pare a una prima ricerca). Bisogna verificare resa e testarne funzionamento prima di integrare questa soluzione.  

**Dovremo poi se funziona riportare la soluzione sul ramo 3.x.**

## Perché 
A causa di un comportamento noto di WebKit (introdotto nel 2020), l'applicazione di `list-style-type: none;` rimuove la natura di "lista" per le tecnologie assistive. Di conseguenza, su Safari + VoiceOver (macOS/iOS), le liste non vengono annunciate come tali e gli item vengono letti in sequenza senza indicare il conteggio o la posizione.

## Altro
### Ci sarebbe un'alternativa probabilmente (breaking per il ramo 2) 
Secondo MDN https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/list-style#accessibility ci sarebbe anche una soluzione puramente HTML per risolvere su Safari (non toccando gli stili scss): aggiungere l'attributo `role="list"` in tutti gli `<ul>` nel markup. Sarebbe da testare e/o documentare come alternativa. **In quel caso sarebbe una breaking change in praticamente tutti i componenti coinvolti** per quanto riguarda **BSI v2**. Potrebbe essere da indagare/preferire per **BSI v3** che già avrà molte breaking. 
Su due piedi in ogni caso preferirei la soluzione solo via scss sia per bsi 2 che 3, più retro-compatibile e non breaking, se le verifiche confermeranno che funziona in tutte le combinazioni. 

**Update: ho implementato nella PR #1751 questa versione. Dai primi test sembra molto più robusta, seppur breaking del markup.**

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
