### PR TITLE
Fix: ripristina semantica liste su Safari/VO (`BI2`): add `role="list"`

### DIFF
--- a/docs/componenti/avatar.md
+++ b/docs/componenti/avatar.md
@@ -214,7 +214,7 @@ Lista verticale di Avatar di dimensione piccola con classe `.size-sm`.
 {% capture example %}
 
 <div class="link-list-wrapper">
-  <ul class="link-list avatar-group">
+  <ul class="link-list avatar-group" role="list">
     <li>
       <a class="list-item" href="#">
         <div class="avatar size-sm"><img src="https://randomuser.me/api/portraits/men/43.jpg" alt="" aria-hidden="true">
@@ -258,7 +258,7 @@ Lista verticale di Avatar di dimensione media con classe `.size-md`.
 {% capture example %}
 
 <div class="link-list-wrapper">
-  <ul class="link-list avatar-group">
+  <ul class="link-list avatar-group" role="list">
     <li>
       <a class="dropdown-item list-item" href="#">
         <div class="avatar size-md"><img src="https://randomuser.me/api/portraits/men/46.jpg" alt="" aria-hidden="true">
@@ -305,7 +305,7 @@ Gruppo di Avatar sovrapposti di dimensione piccola con classe `.size-sm`.
 {% comment %}Example name: Gruppo, sovrapposti piccoli{% endcomment %}
 {% capture example %}
 
-<ul class="avatar-group-stacked">
+<ul class="avatar-group-stacked" role="list">
   <li>
     <a class="avatar size-sm" href="#">
       <img src="https://randomuser.me/api/portraits/women/12.jpg" alt="Arianna Rossi">
@@ -361,7 +361,7 @@ Gruppo di Avatar sovrapposti di dimensione piccola con classe `.size-sm`.
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuToggle1">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li>
                 <a class="dropdown-item list-item" href="#">
                   <div class="avatar size-sm"><img src="https://randomuser.me/api/portraits/men/46.jpg" alt="Mario Rossi"></div>
@@ -408,7 +408,7 @@ Gruppo di Avatar sovrapposti di dimensione media con classe `.size-md`.
 {% comment %}Example name: Gruppo, sovrapposti medi{% endcomment %}
 {% capture example %}
 
-<ul class="avatar-group-stacked">
+<ul class="avatar-group-stacked" role="list">
   <li>
     <a class="avatar size-md" href="#">
       <img src="https://randomuser.me/api/portraits/women/12.jpg" alt="Arianna Rossi">
@@ -446,7 +446,7 @@ Gruppo di Avatar sovrapposti di dimensione media con classe `.size-md`.
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuToggle2">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li>
                 <a class="dropdown-item list-item" href="#">
                   <div class="avatar size-md">

--- a/docs/componenti/card.md
+++ b/docs/componenti/card.md
@@ -156,7 +156,7 @@ La struttura dei metadati include:
       <!--finally the card footer metadata-->
       <footer class="it-card-related it-card-footer">
         <div class="it-card-taxonomy">
-          <ul class="it-card-chips chips-list" aria-label="Argomenti correlati: ">
+          <ul class="it-card-chips chips-list" aria-label="Argomenti correlati: " role="list">
             <li class="list-item"><a class="chip chip-simple chip-sm" href="#">
               <span class="chip-label"><span class="visually-hidden">Argomento: </span>Argomento 1</span>
             </a></li>
@@ -288,7 +288,7 @@ Per indicare l'autore del contenuto, usa l'elemento semantico `address` con clas
       <!--finally the card footer metadata-->
       <footer class="it-card-related it-card-footer">
         <div class="it-card-taxonomy">
-          <ul class="it-card-chips chips-list" aria-label="Argomenti correlati: ">
+          <ul class="it-card-chips chips-list" aria-label="Argomenti correlati: " role="list">
             <li class="list-item"><a class="chip chip-simple chip-sm" href="#">
               <span class="chip-label"><span class="visually-hidden">Argomento: </span>Argomento 1</span>
             </a></li>
@@ -742,7 +742,7 @@ Negli esempi non abbiamo usato il `target` del link per favorire la normale navi
       <!--finally the card footer metadata-->
       <footer class="it-card-related it-card-footer">
         <div class="it-card-taxonomy">
-          <ul class="it-card-chips chips-list" aria-label="Argomenti correlati: ">
+          <ul class="it-card-chips chips-list" aria-label="Argomenti correlati: " role="list">
             <li class="list-item"><a class="chip chip-simple chip-sm" href="#">
               <span class="chip-label"><span class="visually-hidden">Argomento: </span>Argomento 1</span>
             </a></li>
@@ -801,7 +801,7 @@ Negli esempi non abbiamo usato il `target` del link per favorire la normale navi
       <!--finally the card footer metadata-->
       <footer class="it-card-related it-card-footer">
         <div class="it-card-taxonomy">
-          <ul class="it-card-chips chips-list" aria-label="Argomenti correlati: ">
+          <ul class="it-card-chips chips-list" aria-label="Argomenti correlati: " role="list">
             <li class="list-item"><a class="chip chip-simple chip-sm" href="#">
               <span class="chip-label"><span class="visually-hidden">Argomento: </span>Argomento 1</span>
             </a></li>
@@ -1401,7 +1401,7 @@ Puoi combinare questa impostazione con le funzionalità del contenitore `.it-car
       <!--card body content-->
       <div class="it-card-body">
         <p class="it-card-text">Descrizione breve dell'argomento in poche righe non troncate.</p>
-        <ul class="list-group list-group-flush" aria-label="Contenuti in evidenza:">
+        <ul class="list-group list-group-flush" aria-label="Contenuti in evidenza:" role="list">
           <li class="list-group-item"><a href="#">Titolo notizia affine</a></li>
           <li class="list-group-item"><a href="#">Titolo media affine</a></li>
           <li class="list-group-item"><a href="#">Altro titolo scheda affine</a></li>
@@ -1430,7 +1430,7 @@ Puoi combinare questa impostazione con le funzionalità del contenitore `.it-car
       <div class="it-card-body">
         <p class="it-card-subtitle">Dal 17 al 22 novembre</p>
         <p class="it-card-text">Descrizione breve dell'evento in poche righe non troncate.</p>
-        <ul class="list-group list-group-flush" aria-label="Contenuti in evidenza:">
+        <ul class="list-group list-group-flush" aria-label="Contenuti in evidenza:" role="list">
           <li class="list-group-item"><a href="#">Gli artisti</a></li>
           <li class="list-group-item"><a href="#">Il luogo</a></li>
           <li class="list-group-item"><a href="#">Il programma dettagliato</a></li>
@@ -1461,7 +1461,7 @@ Puoi combinare questa impostazione con le funzionalità del contenitore `.it-car
       <!--card body content-->
       <div class="it-card-body">
         <p class="it-card-text">Descrizione breve dell'argomento in poche righe non troncate.</p>
-        <ul class="list-group list-group-flush" aria-label="Contenuti in evidenza:">
+        <ul class="list-group list-group-flush" aria-label="Contenuti in evidenza:" role="list">
           <li class="list-group-item"><a href="#" class="it-card-link">Titolo notizia affine</a></li>
           <li class="list-group-item"><a href="#" class="it-card-link">Titolo media affine</a></li>
           <li class="list-group-item"><a href="#" class="it-card-link">Altro titolo scheda affine</a></li>
@@ -2018,11 +2018,13 @@ Per **gruppi numerosi di card** (come pagine di listini, cataloghi, risultati di
 Con le liste, le tecnologie assistive permettono agli utenti di conoscere il numero totale di componenti card che si stanno esplorando e navigare più facilmente.
 
 Se necessario nel contesto aggiungi una `aria-label` che spieghi i contenuti della lista come nell'esempio che segue. 
+
+Per permettere a Voice Over su Safari di riconoscerle come liste definisci anche l'attributo `role="list"` sull'elemento `<ul>`. 
 {% endcapture %}{% include callout.html content=callout type="accessibility" %}
 
 ```html
 <div class="container-xl">
-  <ul class="it-card-list row" aria-label="Risultati della ricerca: ">
+  <ul class="it-card-list row" aria-label="Risultati della ricerca: " role="list">
     <li class="col-12 col-md-6 col-lg-4 mb-3 mb-md-4">
       <article class="it-card">...</article>
     </li>
@@ -2037,7 +2039,7 @@ Esempio di lista card:
 
 {% comment %}Example name: Lista di card{% endcomment %}
 {% capture example %}
-<ul class="it-card-list row" aria-label="Risultati della ricerca: ">
+<ul class="it-card-list row" aria-label="Risultati della ricerca: " role="list">
   <li class="col-12 col-md-6 col-lg-4 mb-3 mb-md-4">
     <!--start it-card-->
     <article class="it-card it-card-height-full rounded shadow-sm border">

--- a/docs/componenti/dropdown.md
+++ b/docs/componenti/dropdown.md
@@ -42,7 +42,7 @@ Il design di default dei dropdown richiede l'applicazione della classe `.btn-dro
   </button>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
     <div class="link-list-wrapper">
-       class="link-list" role="list">
+       <ul class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -66,7 +66,7 @@ Ovviamente sono disponibili [tutte le varianti]({{ site.baseurl }}/docs/componen
   </button>
   <div class="dropdown-menu">
     <div class="link-list-wrapper">
-       class="link-list" role="list">
+       <ul class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -81,7 +81,7 @@ Ovviamente sono disponibili [tutte le varianti]({{ site.baseurl }}/docs/componen
   </button>
   <div class="dropdown-menu">
     <div class="link-list-wrapper">
-       class="link-list" role="list">
+       <ul class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -96,7 +96,7 @@ Ovviamente sono disponibili [tutte le varianti]({{ site.baseurl }}/docs/componen
   </button>
   <div class="dropdown-menu">
     <div class="link-list-wrapper">
-       class="link-list" role="list">
+      <ul class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -120,7 +120,7 @@ Lo stesso vale per gli elementi `<a>`:
   </a>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
     <div class="link-list-wrapper">
-       class="link-list" role="list">
+       <ul class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -144,7 +144,7 @@ Per aprire le voci di menu verso l'alto aggiungere la classe `.dropup` all'eleme
   </a>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuDropup">
     <div class="link-list-wrapper">
-       class="link-list" role="list">
+       <ul class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -168,7 +168,7 @@ Per aprire le voci di menu verso destra aggiungere la classe `.dropend` all'elem
   </a>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuDropright">
     <div class="link-list-wrapper">
-       class="link-list" role="list">
+       <ul class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -192,7 +192,7 @@ Per aprire le voci di menu verso sinistra aggiungere la classe `.dropstart` all'
   </a>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuDropleft">
     <div class="link-list-wrapper">
-       class="link-list" role="list">
+       <ul class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -215,7 +215,7 @@ Aggiungere la classe `.active` ai link del dropdown che si vogliono mostrare com
 
 <div class="dropdown-menu">
   <div class="link-list-wrapper">
-       class="link-list" role="list">
+       <ul class="link-list" role="list">
         <li><a class="list-item active" href="#"><span>Azione 1</span><span class="visually-hidden"> attivo</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -233,7 +233,7 @@ Aggiungere la classe `.disabled` ai link del dropdown che si vogliono mostrare c
 
 <div class="dropdown-menu">
   <div class="link-list-wrapper">
-       class="link-list" role="list">
+       <ul class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item disabled" href="#" aria-disabled="true"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -252,7 +252,7 @@ All'interno del menu dropdown possono essere inseriti header e separatori.
 <div class="dropdown-menu">
   <div class="link-list-wrapper">
     <div class="link-list-heading">Intestazione</div>
-     class="link-list" role="list">
+     <ul class="link-list" role="list">
       <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
       <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
       <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -274,7 +274,7 @@ Per aumentare la dimensione dei link contenuti nel dropdown è sufficiente aggiu
 
 <div class="dropdown-menu">
   <div class="link-list-wrapper">
-     class="link-list" role="list">
+     <ul class="link-list" role="list">
       <li><a class="list-item large" href="#"><span>Azione 1</span></a></li>
       <li><a class="list-item large" href="#"><span>Azione 2</span></a></li>
       <li><a class="list-item large" href="#"><span>Azione 3</span></a></li>
@@ -292,7 +292,7 @@ Per ottenere un dropdown menu largo quanto l'elemento che contiene il dropdown b
 
 <div class="dropdown-menu full-width">
   <div class="link-list-wrapper">
-     class="link-list" role="list">
+     <ul class="link-list" role="list">
       <li><a class="list-item large" href="#"><span>Azione 1</span></a></li>
       <li><a class="list-item large" href="#"><span>Azione 2</span></a></li>
       <li><a class="list-item large" href="#"><span>Azione 3</span></a></li>
@@ -312,7 +312,7 @@ Ai link contenuti nel menu può essere aggiunta un'icona illustrativa allineata 
 
 <div class="dropdown-menu">
   <div class="link-list-wrapper">
-     class="link-list" role="list">
+     <ul class="link-list" role="list">
       <li>
         <a class="list-item right-icon" href="#">
           <span>Azione 1</span>
@@ -345,7 +345,7 @@ Ai link contenuti nel menu può essere aggiunta un'icona illustrativa allineata 
 
 <div class="dropdown-menu">
   <div class="link-list-wrapper">
-     class="link-list" role="list">
+     <ul class="link-list" role="list">
       <li>
         <a class="list-item left-icon" href="#">
           <svg class="icon icon-sm icon-primary left"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-star-outline"></use></svg>
@@ -379,7 +379,7 @@ Aggiungendo la classe`.dark` al dropdown menu si ottiene una versione in negativ
 <div class="dropdown-menu dark">
   <div class="link-list-wrapper">
     <div class="link-list-heading">Intestazione</div>
-     class="link-list" role="list">
+     <ul class="link-list" role="list">
       <li>
         <a class="list-item right-icon active" href="#">
           <span>Azione 1 (attivo)</span>

--- a/docs/componenti/dropdown.md
+++ b/docs/componenti/dropdown.md
@@ -42,7 +42,7 @@ Il design di default dei dropdown richiede l'applicazione della classe `.btn-dro
   </button>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+       class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -66,7 +66,7 @@ Ovviamente sono disponibili [tutte le varianti]({{ site.baseurl }}/docs/componen
   </button>
   <div class="dropdown-menu">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+       class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -81,7 +81,7 @@ Ovviamente sono disponibili [tutte le varianti]({{ site.baseurl }}/docs/componen
   </button>
   <div class="dropdown-menu">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+       class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -96,7 +96,7 @@ Ovviamente sono disponibili [tutte le varianti]({{ site.baseurl }}/docs/componen
   </button>
   <div class="dropdown-menu">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+       class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -120,7 +120,7 @@ Lo stesso vale per gli elementi `<a>`:
   </a>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+       class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -144,7 +144,7 @@ Per aprire le voci di menu verso l'alto aggiungere la classe `.dropup` all'eleme
   </a>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuDropup">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+       class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -168,7 +168,7 @@ Per aprire le voci di menu verso destra aggiungere la classe `.dropend` all'elem
   </a>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuDropright">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+       class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -192,7 +192,7 @@ Per aprire le voci di menu verso sinistra aggiungere la classe `.dropstart` all'
   </a>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuDropleft">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+       class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -215,7 +215,7 @@ Aggiungere la classe `.active` ai link del dropdown che si vogliono mostrare com
 
 <div class="dropdown-menu">
   <div class="link-list-wrapper">
-      <ul class="link-list">
+       class="link-list" role="list">
         <li><a class="list-item active" href="#"><span>Azione 1</span><span class="visually-hidden"> attivo</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -233,7 +233,7 @@ Aggiungere la classe `.disabled` ai link del dropdown che si vogliono mostrare c
 
 <div class="dropdown-menu">
   <div class="link-list-wrapper">
-      <ul class="link-list">
+       class="link-list" role="list">
         <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
         <li><a class="dropdown-item list-item disabled" href="#" aria-disabled="true"><span>Azione 2</span></a></li>
         <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -252,7 +252,7 @@ All'interno del menu dropdown possono essere inseriti header e separatori.
 <div class="dropdown-menu">
   <div class="link-list-wrapper">
     <div class="link-list-heading">Intestazione</div>
-    <ul class="link-list">
+     class="link-list" role="list">
       <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
       <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
       <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -274,7 +274,7 @@ Per aumentare la dimensione dei link contenuti nel dropdown è sufficiente aggiu
 
 <div class="dropdown-menu">
   <div class="link-list-wrapper">
-    <ul class="link-list">
+     class="link-list" role="list">
       <li><a class="list-item large" href="#"><span>Azione 1</span></a></li>
       <li><a class="list-item large" href="#"><span>Azione 2</span></a></li>
       <li><a class="list-item large" href="#"><span>Azione 3</span></a></li>
@@ -292,7 +292,7 @@ Per ottenere un dropdown menu largo quanto l'elemento che contiene il dropdown b
 
 <div class="dropdown-menu full-width">
   <div class="link-list-wrapper">
-    <ul class="link-list">
+     class="link-list" role="list">
       <li><a class="list-item large" href="#"><span>Azione 1</span></a></li>
       <li><a class="list-item large" href="#"><span>Azione 2</span></a></li>
       <li><a class="list-item large" href="#"><span>Azione 3</span></a></li>
@@ -312,7 +312,7 @@ Ai link contenuti nel menu può essere aggiunta un'icona illustrativa allineata 
 
 <div class="dropdown-menu">
   <div class="link-list-wrapper">
-    <ul class="link-list">
+     class="link-list" role="list">
       <li>
         <a class="list-item right-icon" href="#">
           <span>Azione 1</span>
@@ -345,7 +345,7 @@ Ai link contenuti nel menu può essere aggiunta un'icona illustrativa allineata 
 
 <div class="dropdown-menu">
   <div class="link-list-wrapper">
-    <ul class="link-list">
+     class="link-list" role="list">
       <li>
         <a class="list-item left-icon" href="#">
           <svg class="icon icon-sm icon-primary left"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-star-outline"></use></svg>
@@ -379,7 +379,7 @@ Aggiungendo la classe`.dark` al dropdown menu si ottiene una versione in negativ
 <div class="dropdown-menu dark">
   <div class="link-list-wrapper">
     <div class="link-list-heading">Intestazione</div>
-    <ul class="link-list">
+     class="link-list" role="list">
       <li>
         <a class="list-item right-icon active" href="#">
           <span>Azione 1 (attivo)</span>

--- a/docs/componenti/modale.md
+++ b/docs/componenti/modale.md
@@ -229,7 +229,7 @@ Per formattare correttamente il contenuto di questa modale, aggiungere la classe
             </div>
             <div class="modal-body">
                <div class="link-list-wrapper">
-                   class="link-list" role="list">
+                   <ul class="link-list" role="list">
                      <li>
                         <a class="list-item icon-left" href="#">
                            <svg class="icon icon-primary">

--- a/docs/componenti/modale.md
+++ b/docs/componenti/modale.md
@@ -229,7 +229,7 @@ Per formattare correttamente il contenuto di questa modale, aggiungere la classe
             </div>
             <div class="modal-body">
                <div class="link-list-wrapper">
-                  <ul class="link-list">
+                   class="link-list" role="list">
                      <li>
                         <a class="list-item icon-left" href="#">
                            <svg class="icon icon-primary">

--- a/docs/componenti/steppers.md
+++ b/docs/componenti/steppers.md
@@ -87,7 +87,7 @@ I passi visibili nell'intestazione possono essere corredati da tre classi aggiun
 {% capture example %}
 <div class="steppers">
   <div class="steppers-header">
-    <ul>
+    <ul role="list">
       <li class="confirmed">Primo contenuto <svg class="icon steppers-success" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check"></use></svg><span class="visually-hidden">Confermato</span></li>
       <li class="active">Secondo contenuto <span class="visually-hidden">Attivo</span></li>
       <li>Terzo contenuto</li>
@@ -116,7 +116,7 @@ Nel caso in cui l'icona è semanticamente rilevante e non spiegata dal testo che
 {% capture example %}
 <div class="steppers">
   <div class="steppers-header">
-    <ul>
+    <ul role="list">
       <li class="confirmed"><svg class="icon" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use></svg>Primo contenuto <svg class="icon steppers-success" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check"></use></svg><span class="visually-hidden">Confermato</span></li>
       <li class="active"><svg class="icon" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-lock"></use></svg>Secondo contenuto <span class="visually-hidden">Attivo</span></li>
       <li><svg class="icon" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-settings"></use></svg>Terzo contenuto</li>
@@ -136,7 +136,7 @@ Le label presenti negli steps dell'header possono essere anticipate dal numero o
 {% capture example %}
 <div class="steppers">
   <div class="steppers-header">
-    <ul>
+    <ul role="list">
       <li class="confirmed"><span class="steppers-number"><svg class="icon steppers-success" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check"></use></svg><span class="visually-hidden">Confermato</span></span>Primo contenuto</li>
       <li class="active no-line"><span class="steppers-number"><span class="visually-hidden">Step </span>2</span>Secondo contenuto <span class="visually-hidden">Attivo</span></li>
       <li><span class="steppers-number"><span class="visually-hidden">Step </span>3</span>Terzo contenuto</li>
@@ -164,7 +164,7 @@ Nel caso si stia sviluppando una _Single page application_ oppure una sequenza d
 {% capture example %}
 <div class="steppers">
   <div class="steppers-header">
-    <ul>
+    <ul role="list">
       <li class="confirmed">Primo contenuto <svg class="icon steppers-success" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check"></use></svg><span class="visually-hidden">Confermato</span></li>
       <li class="active">Secondo contenuto <span class="visually-hidden">Attivo</span></li>
       <li>Terzo contenuto</li>
@@ -236,7 +236,7 @@ Per ragioni di accessibilità, i `<li>` devono contenere uno `<span>` con classe
   </div>
   <nav class="steppers-nav">
     <button type="button" class="btn btn-outline-primary btn-sm steppers-btn-prev"><svg class="icon icon-primary"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-chevron-left"></use></svg>Indietro</button>
-    <ul class="steppers-dots">
+    <ul class="steppers-dots" role="list">
       <li class="done"><span class="visually-hidden">Step 1 di 6 - Confermato</span></li>
       <li class="done"><span class="visually-hidden">Step 2 di 6 - Confermato</span></li>
       <li class="done"><span class="visually-hidden">Step 3 di 6 - Confermato</span></li>
@@ -296,7 +296,7 @@ Per ottenere una versione scura degli Stepper è sufficiente aggiungere la class
 {% capture example %}
 <div class="steppers bg-dark">
   <div class="steppers-header">
-    <ul>
+    <ul role="list">
       <li class="confirmed">Primo contenuto <svg class="icon steppers-success" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check"></use></svg><span class="visually-hidden">Confermato</span></li>
       <li class="active">Secondo contenuto <span class="visually-hidden">Attivo</span></li>
       <li>Terzo contenuto</li>
@@ -323,7 +323,7 @@ Per ottenere una versione scura degli Stepper è sufficiente aggiungere la class
 <!-- Solo testo -->
 <div class="steppers bg-dark">
   <div class="steppers-header">
-    <ul>
+    <ul role="list">
       <li class="confirmed">Primo contenuto <svg class="icon steppers-success" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check"></use></svg><span class="visually-hidden">Confermato</span></li>
       <li class="active">Secondo contenuto <span class="visually-hidden">Attivo</span></li>
       <li>Terzo contenuto</li>
@@ -335,7 +335,7 @@ Per ottenere una versione scura degli Stepper è sufficiente aggiungere la class
 <!-- Testo e icone -->
 <div class="steppers bg-dark">
   <div class="steppers-header">
-    <ul>
+    <ul role="list">
       <li class="confirmed"><svg class="icon" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-calendar"></use></svg>Primo contenuto <svg class="icon steppers-success" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check"></use></svg><span class="visually-hidden">Confermato</span></li>
       <li class="active"><svg class="icon" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-lock"></use></svg>Secondo contenuto <span class="visually-hidden">Attivo</span></li>
       <li><svg class="icon" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-settings"></use></svg>Terzo contenuto</li>
@@ -347,7 +347,7 @@ Per ottenere una versione scura degli Stepper è sufficiente aggiungere la class
 <!-- Numeri -->
 <div class="steppers bg-dark">
   <div class="steppers-header">
-    <ul>
+    <ul role="list">
       <li class="confirmed"><span class="steppers-number"><svg class="icon steppers-success" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-check"></use></svg><span class="visually-hidden">Confermato Step 1</span></span>Primo contenuto</li>
       <li class="active no-line"><span class="steppers-number"><span class="visually-hidden">Attivo Step </span>2</span>Secondo contenuto</li>
       <li><span class="steppers-number"><span class="visually-hidden">Step </span>3</span>Terzo contenuto</li>
@@ -395,7 +395,7 @@ Si raccomanda la visualizzazione in un viewport ridotto per ottenere un esempio 
   </div>
   <nav class="steppers-nav">
     <button type="button" class="btn btn-outline-primary btn-sm steppers-btn-prev"><svg class="icon icon-primary"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-chevron-left"></use></svg>Indietro</button>
-    <ul class="steppers-dots">
+    <ul class="steppers-dots" role="list">
       <li class="done"><span class="visually-hidden">Step 1 di 6 - Confermato</span></li>
       <li class="done"><span class="visually-hidden">Step 2 di 6 - Confermato</span></li>
       <li class="done"><span class="visually-hidden">Step 3 di 6 - Confermato</span></li>

--- a/docs/componenti/sticky.md
+++ b/docs/componenti/sticky.md
@@ -115,7 +115,7 @@ In tal caso è necessario utilizzare l'attributo `data-bs-target`.
                   </svg>
                 </a>
                 <div class="link-list-wrapper collapse" id="menuC1">
-                  <ul class="link-list">
+                  <ul class="link-list" role="list">
                     <li><a class="dropdown-item list-item" href="#">Link 1</a></li>
                     <li><a class="list-item active" href="#" aria-current="page">Link 2 (Attivo)</a></li>
                   </ul>

--- a/docs/esempi/navscroll/index.html
+++ b/docs/esempi/navscroll/index.html
@@ -19,7 +19,7 @@ title: NavScroll
                   </svg>
                 </a>
                 <div class="link-list-wrapper collapse" id="menuC1">
-                  <ul class="link-list">
+                  <ul class="link-list" role="list">
                     <li><a class="dropdown-item list-item" href="#">Link 1</a></li>
                     <li><a class="list-item active" href="#" aria-current="page">Link 2 (Attivo)</a></li>
                   </ul>
@@ -156,7 +156,7 @@ title: NavScroll
                       </a>
                       <div class="dropdown-menu" role="region" aria-labelledby="mainNavDropdownC1">
                         <div class="link-list-wrapper">
-                          <ul class="link-list">
+                          <ul class="link-list" role="list">
                             <li><a class="dropdown-item list-item" href="#"><span>Link lista 1</span></a></li>
                             <li><a class="dropdown-item list-item" href="#"><span>Link lista 2</span></a></li>
                             <li><a class="dropdown-item list-item" href="#"><span>Link lista 3</span></a></li>
@@ -206,7 +206,7 @@ title: NavScroll
                               <div class="row">
                                 <div class="col-12 col-lg-6">
                                   <div class="link-list-wrapper">
-                                    <ul class="link-list">
+                                    <ul class="link-list" role="list">
                                       <li>
                                         <a class="list-item dropdown-item" href="#">
                                           <svg role="img" class="icon icon-sm me-2">
@@ -585,7 +585,7 @@ title: NavScroll
               <a href="#" title="Vai alla pagina: Amministrazione">Amministrazione</a>
             </h4>
             <div class="link-list-wrapper">
-              <ul class="footer-list link-list clearfix">
+              <ul class="footer-list link-list clearfix" role="list">
                 <li><a class="list-item" href="#" title="Vai alla pagina: Giunta e consiglio">Giunta e consiglio</a>
                 </li>
                 <li><a class="list-item" href="#" title="Vai alla pagina: Aree di competenza">Aree di competenza</a>
@@ -603,7 +603,7 @@ title: NavScroll
               <a href="#" title="Vai alla pagina: Servizi">Servizi</a>
             </h4>
             <div class="link-list-wrapper">
-              <ul class="footer-list link-list clearfix">
+              <ul class="footer-list link-list clearfix" role="list">
                 <li><a class="list-item" href="#" title="Vai alla pagina: Pagamenti">Pagamenti</a></li>
                 <li><a class="list-item" href="#" title="Vai alla pagina: Sostegno">Sostegno</a></li>
                 <li><a class="list-item" href="#" title="Vai alla pagina: Domande e iscrizioni">Domande e iscrizioni</a>
@@ -621,7 +621,7 @@ title: NavScroll
               <a href="#" title="Vai alla pagina: Novità">Novità</a>
             </h4>
             <div class="link-list-wrapper">
-              <ul class="footer-list link-list clearfix">
+              <ul class="footer-list link-list clearfix" role="list">
                 <li><a class="list-item" href="#" title="Vai alla pagina: Notizie">Notizie</a></li>
                 <li><a class="list-item" href="#" title="Vai alla pagina: Eventi">Eventi</a></li>
                 <li><a class="list-item" href="#" title="Vai alla pagina: Comunicati stampa">Comunicati stampa</a></li>
@@ -633,7 +633,7 @@ title: NavScroll
               <a href="#" title="Vai alla pagina: Documenti">Documenti</a>
             </h4>
             <div class="link-list-wrapper">
-              <ul class="footer-list link-list clearfix">
+              <ul class="footer-list link-list clearfix" role="list">
                 <li><a class="list-item" href="#" title="Vai alla pagina: Progetti e attività">Progetti e attività</a>
                 </li>
                 <li><a class="list-item" href="#" title="Vai alla pagina: Delibere, determine e ordinanze">Delibere,
@@ -655,7 +655,7 @@ title: NavScroll
               Via Roma 0 - 00000 Lorem Ipsum Codice fiscale / P. IVA: 000000000
             </p>
             <div class="link-list-wrapper">
-              <ul class="footer-list link-list clearfix">
+              <ul class="footer-list link-list clearfix" role="list">
                 <li><a class="list-item" href="#" title="Vai alla pagina: Posta Elettronica Certificata">Posta
                     Elettronica Certificata</a></li>
                 <li>
@@ -671,7 +671,7 @@ title: NavScroll
           <div class="col-lg-4 col-md-4 pb-2">
             <div class="pb-2">
               <h4><a href="#" title="Vai alla pagina: Seguici su">Seguici su</a></h4>
-              <ul class="list-inline text-left social">
+              <ul class="list-inline text-left social" role="list">
                 <li class="list-inline-item">
                   <a class="p-2 text-white" href="#" target="_blank">
                     <svg class="icon icon-sm icon-white align-top">
@@ -718,7 +718,7 @@ title: NavScroll
   <div class="it-footer-small-prints clearfix">
     <div class="container">
       <h3 class="visually-hidden">Sezione Link Utili</h3>
-      <ul class="it-footer-small-prints-list list-inline mb-0 d-flex flex-column flex-md-row">
+      <ul class="it-footer-small-prints-list list-inline mb-0 d-flex flex-column flex-md-row" role="list">
         <li class="list-inline-item"><a href="#" title="Note Legali">Media policy</a></li>
         <li class="list-inline-item"><a href="#" title="Note Legali">Note legali</a></li>
         <li class="list-inline-item"><a href="#" title="Privacy-Cookies">Privacy policy</a></li>

--- a/docs/esempi/sticky-target/index.html
+++ b/docs/esempi/sticky-target/index.html
@@ -33,7 +33,7 @@ title: Sticky
                   </svg>
                 </a>
                 <div class="link-list-wrapper collapse" id="menuC1">
-                  <ul class="link-list">
+                  <ul class="link-list" role="list">
                     <li><a class="dropdown-item list-item" href="#">Link 1</a></li>
                     <li><a class="list-item active" href="#" aria-current="page">Link 2 (Attivo)</a></li>
                   </ul>

--- a/docs/form/input.md
+++ b/docs/form/input.md
@@ -483,7 +483,7 @@ Il testo corrispondente alla ricerca (_"ite"_, nell'esempio) deve essere racchiu
   <span class="autocomplete-icon" aria-hidden="true">
     <svg class="icon icon-sm"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-search"></use></svg>
   </span>
-  <ul class="autocomplete-list" id="testAutocomplete1">
+  <ul class="autocomplete-list" id="testAutocomplete1" role="list">
     <li>
       <a href="#">
         <div class="avatar size-sm">
@@ -554,7 +554,7 @@ Per ottenere una versione grande dell'Autocomplete, indicata ad esempio per inte
   <span class="autocomplete-icon" aria-hidden="true">
     <svg class="icon icon-sm"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-search"></use></svg>
   </span>
-  <ul class="autocomplete-list" id="testAutocomplete2">
+  <ul class="autocomplete-list" id="testAutocomplete2" role="list">
     <li>
       <a href="#">
         <div class="avatar size-sm">

--- a/docs/form/upload.md
+++ b/docs/form/upload.md
@@ -38,7 +38,7 @@ Come è evidente dall'esempio sottostante è sempre necessario includere informa
     <svg class="icon icon-sm" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-upload"></use></svg>
     <span>Carica file</span>
   </label>
-  <ul class="upload-file-list">
+  <ul class="upload-file-list" role="list">
     <li class="upload-file success">
       <svg class="icon icon-sm" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-file"></use></svg>
       <p>
@@ -106,7 +106,7 @@ Il componente ottimizza la visualizzazione delle immagini anche quando queste no
     <svg class="icon icon-sm" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-upload"></use></svg>
     <span>Carica file</span>
   </label>
-  <ul class="upload-file-list upload-file-list-image">
+  <ul class="upload-file-list upload-file-list-image" role="list">
     <li class="upload-file success">
       <div class="upload-image">
         <img src="https://picsum.photos/40/40?image=1055" alt="descrizione immagine">
@@ -235,7 +235,7 @@ Anche in questo caso, nonostante il componente ottimizzi la visualizzazione dell
 {% comment %}Example name: Galleria {% endcomment %}
 {% capture example %}
 <form method="post" action="" enctype="multipart/form-data">
-  <ul class="upload-pictures-wall">
+  <ul class="upload-pictures-wall" role="list">
     <li>
       <input type="file" name="upload5" id="upload5" class="upload pictures-wall" multiple="multiple" />
       <label for="upload5">
@@ -250,7 +250,7 @@ Anche in questo caso, nonostante il componente ottimizzi la visualizzazione dell
 <p class="mt-5"><strong>Esempio Immagini Caricate</strong></p>
 
 <form method="post" action="" enctype="multipart/form-data">
-  <ul class="upload-pictures-wall">
+  <ul class="upload-pictures-wall" role="list">
     <li>
       <div class="upload-image">
         <img src="https://picsum.photos/128/128?image=1020" alt="descrizione immagine">

--- a/docs/menu-di-navigazione/bottomnav.md
+++ b/docs/menu-di-navigazione/bottomnav.md
@@ -36,7 +36,7 @@ Il link `<a>` attivo possiede una classe `.active`.
 {% comment %}Example name: Base{% endcomment %}
 {% capture example %}
 <nav class="bottom-nav">
-  <ul>
+  <ul role="list">
     <li>
       <a href="#" class="active">
         <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-comment"></use></svg>
@@ -64,7 +64,7 @@ I link occupano automaticamente tutto lo spazio orizzontale disponibile. Qui di 
 {% comment %}Example name: Base, con 4 link{% endcomment %}
 {% capture example %}
 <nav class="bottom-nav">
-  <ul>
+  <ul role="list">
     <li>
       <a href="#" class="active">
         <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-comment"></use></svg>
@@ -100,7 +100,7 @@ Aggiungere uno `<span>` con classe `.bottom-nav-badge` all'interno dell'icona pe
 {% comment %}Example name: Con badge{% endcomment %}
 {% capture example %}
 <nav class="bottom-nav">
-  <ul>
+  <ul role="list">
     <li>
       <a href="#">
         <div class="badge-wrapper"><span class="bottom-nav-badge">1</span></div>
@@ -152,7 +152,7 @@ I badge e gli alert sono nascosti agli screen reader. Per garantire l'accessibil
 {% comment %}Example name: Con alert{% endcomment %}
 {% capture example %}
 <nav class="bottom-nav">
-  <ul>
+  <ul role="list">
     <li>
       <a href="#" class="active">
         <div class="badge-wrapper"><span class="bottom-nav-alert"></span></div>

--- a/docs/menu-di-navigazione/footer.md
+++ b/docs/menu-di-navigazione/footer.md
@@ -41,7 +41,7 @@ Potrebbe anche contenere riferimenti alle pagine social dell'amministrazione.
               <a href="#" title="Vai alla pagina: Amministrazione">Amministrazione</a>
             </h4>
             <div class="link-list-wrapper">
-              <ul class="footer-list link-list clearfix">
+              <ul class="footer-list link-list clearfix" role="list">
                 <li><a class="list-item" href="#">Giunta e consiglio</a></li>
                 <li><a class="list-item" href="#">Aree di competenza</a></li>
                 <li><a class="list-item" href="#">Dipendenti</a></li>
@@ -55,7 +55,7 @@ Potrebbe anche contenere riferimenti alle pagine social dell'amministrazione.
               <a href="#" title="Vai alla pagina: Servizi">Servizi</a>
             </h4>
             <div class="link-list-wrapper">
-              <ul class="footer-list link-list clearfix">
+              <ul class="footer-list link-list clearfix" role="list">
                 <li><a class="list-item" href="#">Pagamenti</a></li>
                 <li><a class="list-item" href="#">Sostegno</a></li>
                 <li><a class="list-item" href="#">Domande e iscrizioni</a></li>
@@ -70,7 +70,7 @@ Potrebbe anche contenere riferimenti alle pagine social dell'amministrazione.
               <a href="#" title="Vai alla pagina: Novità">Novità</a>
             </h4>
             <div class="link-list-wrapper">
-              <ul class="footer-list link-list clearfix">
+              <ul class="footer-list link-list clearfix" role="list">
                 <li><a class="list-item" href="#">Notizie</a></li>
                 <li><a class="list-item" href="#">Eventi</a></li>
                 <li><a class="list-item" href="#">Comunicati stampa</a></li>
@@ -82,7 +82,7 @@ Potrebbe anche contenere riferimenti alle pagine social dell'amministrazione.
               <a href="#" title="Vai alla pagina: Documenti">Documenti</a>
             </h4>
             <div class="link-list-wrapper">
-              <ul class="footer-list link-list clearfix">
+              <ul class="footer-list link-list clearfix" role="list">
                 <li><a class="list-item" href="#">Progetti e attività</a></li>
                 <li><a class="list-item" href="#">Delibere, determine e ordinanze</a></li>
                 <li><a class="list-item" href="#">Bandi</a></li>
@@ -102,7 +102,7 @@ Potrebbe anche contenere riferimenti alle pagine social dell'amministrazione.
               Via Roma 0 - 00000 Lorem Ipsum Codice fiscale / P. IVA: 000000000
             </p>
             <div class="link-list-wrapper">
-              <ul class="footer-list link-list clearfix">
+              <ul class="footer-list link-list clearfix" role="list">
                 <li><a class="list-item" href="#">Posta Elettronica Certificata</a></li>
                 <li>
                   <a class="list-item" href="#">URP - Ufficio Relazioni con il Pubblico</a>
@@ -116,7 +116,7 @@ Potrebbe anche contenere riferimenti alle pagine social dell'amministrazione.
           <div class="col-lg-4 col-md-4 pb-2">
             <div class="pb-2">
               <h4>Seguici su</h4>
-              <ul class="list-inline text-left social">
+              <ul class="list-inline text-left social" role="list">
                 <li class="list-inline-item">
                   <a class="p-2 text-white" href="#"><svg class="icon icon-sm icon-white align-top"><use xlink:href="{{site.baseurl}}/dist/svg/sprites.svg#it-designers-italia"></use></svg><span class="visually-hidden">Designers Italia (link esterno)</span></a>
                 </li>
@@ -139,7 +139,7 @@ Potrebbe anche contenere riferimenti alle pagine social dell'amministrazione.
   <div class="it-footer-small-prints clearfix">
     <div class="container">
       <!-- <h3 class="visually-hidden">Sezione Link Utili</h3> -->
-      <ul class="it-footer-small-prints-list list-inline mb-0 d-flex flex-column flex-md-row">
+      <ul class="it-footer-small-prints-list list-inline mb-0 d-flex flex-column flex-md-row" role="list">
         <li class="list-inline-item"><a href="#">Media policy</a></li>
         <li class="list-inline-item"><a href="#">Note legali</a></li>
         <li class="list-inline-item"><a href="#">Privacy policy</a></li>
@@ -181,7 +181,7 @@ Potrebbe anche contenere riferimenti alle pagine social dell'amministrazione.
               Via Roma 0 - 00000 Lorem Ipsum Codice fiscale / P. IVA: 000000000
             </p>
             <div class="link-list-wrapper">
-              <ul class="footer-list link-list clearfix">
+              <ul class="footer-list link-list clearfix" role="list">
                 <li><a class="list-item" href="#">Posta Elettronica Certificata</a></li>
                 <li>
                   <a class="list-item" href="#">URP - Ufficio Relazioni con il Pubblico</a>
@@ -195,7 +195,7 @@ Potrebbe anche contenere riferimenti alle pagine social dell'amministrazione.
           <div class="col-lg-4 col-md-4 pb-2">
             <div class="pb-2">
               <h4>Seguici su</h4>
-              <ul class="list-inline text-left social">
+              <ul class="list-inline text-left social" role="list">
                 <li class="list-inline-item">
                   <a class="p-2 text-white" href="#"><svg class="icon icon-sm icon-white align-top"><use xlink:href="{{site.baseurl}}/dist/svg/sprites.svg#it-designers-italia"></use></svg><span class="visually-hidden">Designers Italia (link esterno)</span></a>
                 </li>
@@ -218,7 +218,7 @@ Potrebbe anche contenere riferimenti alle pagine social dell'amministrazione.
   <div class="it-footer-small-prints clearfix">
     <div class="container">
       <!-- <h3 class="visually-hidden">Sezione Link Utili</h3> -->
-      <ul class="it-footer-small-prints-list list-inline mb-0 d-flex flex-column flex-md-row">
+      <ul class="it-footer-small-prints-list list-inline mb-0 d-flex flex-column flex-md-row" role="list">
         <li class="list-inline-item"><a href="#">Media policy</a></li>
         <li class="list-inline-item"><a href="#">Note legali</a></li>
         <li class="list-inline-item"><a href="#">Privacy policy</a></li>

--- a/docs/menu-di-navigazione/header.md
+++ b/docs/menu-di-navigazione/header.md
@@ -53,7 +53,7 @@ Il cambio lingua è gestito con il componente [dropdown]({{ site.baseurl }}/docs
                 <svg class="icon" aria-hidden="true"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-expand"></use></svg>
               </a>
               <div class="link-list-wrapper collapse" id="menu1a">
-                <ul class="link-list">
+                <ul class="link-list" role="list">
                   <li><a class="dropdown-item list-item" href="#">Link 1</a></li>
                   <li><a class="list-item active" href="#" aria-current="page">Link 2 (Attivo)</a></li>
                 </ul>
@@ -71,7 +71,7 @@ Il cambio lingua è gestito con il componente [dropdown]({{ site.baseurl }}/docs
                 <div class="row">
                   <div class="col-12">
                     <div class="link-list-wrapper">
-                      <ul class="link-list">
+                      <ul class="link-list" role="list">
                         <li><a class="dropdown-item list-item" href="#"><span>ITA <span class="visually-hidden">selezionata</span></span></a></li>
                         <li><a class="dropdown-item list-item" href="#"><span>ENG</span></a></li>
                       </ul>
@@ -117,7 +117,7 @@ Il modificatore `.btn-full` è disponibile anche con il tema chiaro attivato da 
                 <div class="row">
                   <div class="col-12">
                     <div class="link-list-wrapper">
-                      <ul class="link-list">
+                      <ul class="link-list" role="list">
                         <li><a class="dropdown-item list-item" href="#"><span>ITA <span class="visually-hidden">selezionata</span></span></a></li>
                         <li><a class="dropdown-item list-item" href="#"><span>ENG</span></a></li>
                       </ul>
@@ -161,7 +161,7 @@ Per cambiare tema all'header slim è sufficiente aggiungere la classe `theme-lig
                 <svg class="icon" aria-hidden="true"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-expand"></use></svg>
               </a>
               <div class="link-list-wrapper collapse" id="menu1b">
-                <ul class="link-list">
+                <ul class="link-list" role="list">
                   <li><a class="dropdown-item list-item" href="#">Link 1</a></li>
                   <li><a class="list-item active" href="#" aria-current="page">Link 2 (Attivo)</a></li>
                 </ul>
@@ -179,7 +179,7 @@ Per cambiare tema all'header slim è sufficiente aggiungere la classe `theme-lig
                 <div class="row">
                   <div class="col-12">
                     <div class="link-list-wrapper">
-                      <ul class="link-list">
+                      <ul class="link-list" role="list">
                         <li><a class="dropdown-item list-item" href="#"><span>ITA <span class="visually-hidden">selezionata</span></span></a></li>
                         <li><a class="dropdown-item list-item" href="#"><span>ENG</span></a></li>
                       </ul>
@@ -429,7 +429,7 @@ Per cambiare tema all'header centrale è sufficiente aggiungere la classe `theme
                   </a>
                   <div class="dropdown-menu" role="region" aria-labelledby="mainNavDropdown1">
                     <div class="link-list-wrapper">
-                      <ul class="link-list">
+                      <ul class="link-list" role="list">
                         <li><a class="dropdown-item list-item" href="#"><span>Link lista 1</span></a></li>
                         <li><a class="dropdown-item list-item" href="#"><span>Link lista 2</span></a></li>
                         <li><a class="dropdown-item list-item" href="#"><span>Link lista 3</span></a></li>
@@ -472,7 +472,7 @@ Per cambiare tema all'header centrale è sufficiente aggiungere la classe `theme
                           <div class="row">
                             <div class="col-12 col-lg-6">
                               <div class="link-list-wrapper">
-                                <ul class="link-list">
+                                <ul class="link-list" role="list">
                                   <li>
                                     <a class="list-item dropdown-item" href="#">
                                       <svg role="img" class="icon icon-sm me-2"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-arrow-right-triangle"></use></svg>
@@ -496,7 +496,7 @@ Per cambiare tema all'header centrale è sufficiente aggiungere la classe `theme
                             </div>
                             <div class="col-12 col-lg-6">
                               <div class="link-list-wrapper">
-                                <ul class="link-list">
+                                <ul class="link-list" role="list">
                                   <li>
                                     <a class="list-item dropdown-item" href="#">
                                       <svg role="img" class="icon icon-sm me-2"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-arrow-right-triangle"></use></svg>
@@ -579,7 +579,7 @@ Per modificare il tema dell'Header Nav è sufficiente aggiungere una o tutte e d
                   </a>
                   <div class="dropdown-menu" role="region" aria-labelledby="mainNavDropdown0">
                     <div class="link-list-wrapper">
-                      <ul class="link-list">
+                      <ul class="link-list" role="list">
                         <li><a class="dropdown-item list-item" href="#"><span>Link lista 1</span></a></li>
                         <li><a class="dropdown-item list-item" href="#"><span>Link lista 2</span></a></li>
                         <li><a class="dropdown-item list-item" href="#"><span>Link lista 3</span></a></li>
@@ -622,7 +622,7 @@ Per modificare il tema dell'Header Nav è sufficiente aggiungere una o tutte e d
                           <div class="row">
                             <div class="col-12 col-lg-6">
                               <div class="link-list-wrapper">
-                                <ul class="link-list">
+                                <ul class="link-list" role="list">
                                   <li>
                                     <a class="list-item dropdown-item" href="#">
                                       <svg role="img" class="icon icon-sm me-2"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-arrow-right-triangle"></use></svg>
@@ -646,7 +646,7 @@ Per modificare il tema dell'Header Nav è sufficiente aggiungere una o tutte e d
                             </div>
                             <div class="col-12 col-lg-6">
                               <div class="link-list-wrapper">
-                                <ul class="link-list">
+                                <ul class="link-list" role="list">
                                   <li>
                                     <a class="list-item dropdown-item" href="#">
                                       <svg role="img" class="icon icon-sm me-2"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-arrow-right-triangle"></use></svg>
@@ -717,7 +717,7 @@ Per modificare il tema dell'Header Nav è sufficiente aggiungere una o tutte e d
                   </a>
                   <div class="dropdown-menu" role="region" aria-labelledby="mainNavDropdown2">
                     <div class="link-list-wrapper">
-                      <ul class="link-list">
+                      <ul class="link-list" role="list">
                         <li><a class="dropdown-item list-item" href="#"><span>Link lista 1</span></a></li>
                         <li><a class="dropdown-item list-item" href="#"><span>Link lista 2</span></a></li>
                         <li><a class="dropdown-item list-item" href="#"><span>Link lista 3</span></a></li>
@@ -760,7 +760,7 @@ Per modificare il tema dell'Header Nav è sufficiente aggiungere una o tutte e d
                           <div class="row">
                             <div class="col-12 col-lg-6">
                               <div class="link-list-wrapper">
-                                <ul class="link-list">
+                                <ul class="link-list" role="list">
                                   <li>
                                     <a class="list-item dropdown-item" href="#">
                                       <svg role="img" class="icon icon-sm me-2"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-arrow-right-triangle"></use></svg>
@@ -784,7 +784,7 @@ Per modificare il tema dell'Header Nav è sufficiente aggiungere una o tutte e d
                             </div>
                             <div class="col-12 col-lg-6">
                               <div class="link-list-wrapper">
-                                <ul class="link-list">
+                                <ul class="link-list" role="list">
                                   <li>
                                     <a class="list-item dropdown-item" href="#">
                                       <svg role="img" class="icon icon-sm me-2"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-arrow-right-triangle"></use></svg>
@@ -857,7 +857,7 @@ Per modificare il tema dell'Header Nav è sufficiente aggiungere una o tutte e d
                   </a>
                   <div class="dropdown-menu" role="region" aria-labelledby="mainNavDropdown3">
                     <div class="link-list-wrapper">
-                      <ul class="link-list">
+                      <ul class="link-list" role="list">
                         <li><a class="dropdown-item list-item" href="#"><span>Link lista 1</span></a></li>
                         <li><a class="dropdown-item list-item" href="#"><span>Link lista 2</span></a></li>
                         <li><a class="dropdown-item list-item" href="#"><span>Link lista 3</span></a></li>
@@ -900,7 +900,7 @@ Per modificare il tema dell'Header Nav è sufficiente aggiungere una o tutte e d
                           <div class="row">
                             <div class="col-12 col-lg-6">
                               <div class="link-list-wrapper">
-                                <ul class="link-list">
+                                <ul class="link-list" role="list">
                                   <li>
                                     <a class="list-item dropdown-item" href="#">
                                       <svg role="img" class="icon icon-sm me-2"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-arrow-right-triangle"></use></svg>
@@ -924,7 +924,7 @@ Per modificare il tema dell'Header Nav è sufficiente aggiungere una o tutte e d
                             </div>
                             <div class="col-12 col-lg-6">
                               <div class="link-list-wrapper">
-                                <ul class="link-list">
+                                <ul class="link-list" role="list">
                                   <li>
                                     <a class="list-item dropdown-item" href="#">
                                       <svg role="img" class="icon icon-sm me-2"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-arrow-right-triangle"></use></svg>
@@ -1024,7 +1024,7 @@ Al menu di navigazione principale può essere aggiunto anche un menu di navigazi
                   <svg class="icon" aria-hidden="true"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-expand"></use></svg>
                 </a>
                 <div class="link-list-wrapper collapse" id="menuC1">
-                  <ul class="link-list">
+                  <ul class="link-list" role="list">
                     <li><a class="dropdown-item list-item" href="#">Link 1</a></li>
                     <li><a class="list-item active" href="#" aria-current="page">Link 2 (Attivo)</a></li>
                   </ul>
@@ -1042,7 +1042,7 @@ Al menu di navigazione principale può essere aggiunto anche un menu di navigazi
                   <div class="row">
                     <div class="col-12">
                       <div class="link-list-wrapper">
-                        <ul class="link-list">
+                        <ul class="link-list" role="list">
                           <li><a class="dropdown-item list-item" href="#"><span>ITA <span class="visually-hidden">selezionata</span></span></a></li>
                           <li><a class="dropdown-item list-item" href="#"><span>ENG</span></a></li>
                         </ul>
@@ -1143,7 +1143,7 @@ Al menu di navigazione principale può essere aggiunto anche un menu di navigazi
                       </a>
                       <div class="dropdown-menu" role="region" aria-labelledby="mainNavDropdownC1">
                         <div class="link-list-wrapper">
-                          <ul class="link-list">
+                          <ul class="link-list" role="list">
                             <li><a class="dropdown-item list-item" href="#"><span>Link lista 1</span></a></li>
                             <li><a class="dropdown-item list-item" href="#"><span>Link lista 2</span></a></li>
                             <li><a class="dropdown-item list-item" href="#"><span>Link lista 3</span></a></li>
@@ -1186,7 +1186,7 @@ Al menu di navigazione principale può essere aggiunto anche un menu di navigazi
                               <div class="row">
                                 <div class="col-12 col-lg-6">
                                   <div class="link-list-wrapper">
-                                    <ul class="link-list">
+                                    <ul class="link-list" role="list">
                                       <li>
                                         <a class="list-item dropdown-item" href="#">
                                           <svg role="img" class="icon icon-sm me-2"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-arrow-right-triangle"></use></svg>
@@ -1210,7 +1210,7 @@ Al menu di navigazione principale può essere aggiunto anche un menu di navigazi
                                 </div>
                                 <div class="col-12 col-lg-6">
                                   <div class="link-list-wrapper">
-                                    <ul class="link-list">
+                                    <ul class="link-list" role="list">
                                       <li>
                                         <a class="list-item dropdown-item" href="#">
                                           <svg role="img" class="icon icon-sm me-2"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-arrow-right-triangle"></use></svg>
@@ -1272,7 +1272,7 @@ Verrà creata un'ombra per enfatizzare l'Header rispetto alla pagina in cui è c
                   <svg class="icon" aria-hidden="true"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-expand"></use></svg>
                 </a>
                 <div class="link-list-wrapper collapse" id="menuC2">
-                  <ul class="link-list">
+                  <ul class="link-list" role="list">
                     <li><a class="dropdown-item list-item" href="#">Link 1</a></li>
                     <li><a class="list-item active" href="#" aria-current="page">Link 2 (Attivo)</a></li>
                   </ul>
@@ -1290,7 +1290,7 @@ Verrà creata un'ombra per enfatizzare l'Header rispetto alla pagina in cui è c
                   <div class="row">
                     <div class="col-12">
                       <div class="link-list-wrapper">
-                        <ul class="link-list">
+                        <ul class="link-list" role="list">
                           <li><a class="dropdown-item list-item" href="#"><span>ITA <span class="visually-hidden">selezionata</span></span></a></li>
                           <li><a class="dropdown-item list-item" href="#"><span>ENG</span></a></li>
                         </ul>
@@ -1385,7 +1385,7 @@ Verrà creata un'ombra per enfatizzare l'Header rispetto alla pagina in cui è c
                       </a>
                       <div class="dropdown-menu" role="region" aria-labelledby="mainNavDropdownC2">
                         <div class="link-list-wrapper">
-                          <ul class="link-list">
+                          <ul class="link-list" role="list">
                             <li><a class="dropdown-item list-item" href="#"><span>Link lista 1</span></a></li>
                             <li><a class="dropdown-item list-item" href="#"><span>Link lista 2</span></a></li>
                             <li><a class="dropdown-item list-item" href="#"><span>Link lista 3</span></a></li>
@@ -1428,7 +1428,7 @@ Verrà creata un'ombra per enfatizzare l'Header rispetto alla pagina in cui è c
                               <div class="row">
                                 <div class="col-12 col-lg-6">
                                   <div class="link-list-wrapper">
-                                    <ul class="link-list">
+                                    <ul class="link-list" role="list">
                                       <li>
                                         <a class="list-item dropdown-item" href="#">
                                           <svg role="img" class="icon icon-sm me-2"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-arrow-right-triangle"></use></svg>
@@ -1452,7 +1452,7 @@ Verrà creata un'ombra per enfatizzare l'Header rispetto alla pagina in cui è c
                                 </div>
                                 <div class="col-12 col-lg-6">
                                   <div class="link-list-wrapper">
-                                    <ul class="link-list">
+                                    <ul class="link-list" role="list">
                                       <li>
                                         <a class="list-item dropdown-item" href="#">
                                           <svg role="img" class="icon icon-sm me-2"><use href="{{site.baseurl}}/dist/svg/sprites.svg#it-arrow-right-triangle"></use></svg>

--- a/docs/menu-di-navigazione/navscroll.md
+++ b/docs/menu-di-navigazione/navscroll.md
@@ -78,6 +78,8 @@ In questo esempio, la linea che limita la barra di navigazione è posizionata a 
                 <a class="nav-link" href="#"><span>1.3 Elemento annidato </span></a>
               </li>
             </ul>
+          </li>
+          <li class="nav-item">
             <a class="nav-link" href="#"><span>2. Sezione </span></a>
             <ul class="link-list">
               <li class="nav-link">
@@ -144,6 +146,8 @@ In questo esempio, la linea che limita la barra di navigazione è posizionata a 
                 <a class="nav-link" href="#"><span>1.3 Elemento annidato </span></a>
               </li>
             </ul>
+          </li>
+          <li class="nav-item">
             <a class="nav-link" href="#"><span>2. Sezione </span></a>
             <ul class="link-list">
               <li class="nav-link">
@@ -292,6 +296,8 @@ Per cambiare il tema è sufficiente aggiungere le seguenti classi al tag `<nav c
                 <a class="nav-link" href="#"><span>1.3 Elemento annidato </span></a>
               </li>
             </ul>
+          </li>
+          <li class="nav-item">
             <a class="nav-link" href="#"><span>2. Sezione </span></a>
             <ul class="link-list">
               <li class="nav-link">

--- a/docs/menu-di-navigazione/sidebar.md
+++ b/docs/menu-di-navigazione/sidebar.md
@@ -21,7 +21,7 @@ Per differenziare a livello stilistico i link secondari, è sufficiente aggiunge
 <div class="sidebar-wrapper">
   <div class="sidebar-linklist-wrapper">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+      <ul class="link-list" role="list">
         <li>
           <h3 class="no_toc">Header</h3>
         </li>
@@ -38,7 +38,7 @@ Per differenziare a livello stilistico i link secondari, è sufficiente aggiunge
   </div>
   <div class="sidebar-linklist-wrapper linklist-secondary">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+      <ul class="link-list" role="list">
         <li><a class="list-item" href="#"><span>Link secondario 1</span></a>
         </li>
         <li><a class="list-item active" href="#"><span>Link secondario 2 (attivo)</span></a>
@@ -60,7 +60,7 @@ La sidebar può contenere icone nella sua Lista di link.
 <div class="sidebar-wrapper">
   <div class="sidebar-linklist-wrapper">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+      <ul class="link-list" role="list">
         <li>
           <h3 class="no_toc">Header</h3>
         </li>
@@ -97,7 +97,7 @@ La sidebar può contenere icone nella sua Lista di link.
   </div>
   <div class="sidebar-linklist-wrapper linklist-secondary">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+      <ul class="link-list" role="list">
         <li><a class="list-item" href="#"><span>Link secondario 1</span></a>
         </li>
         <li><a class="list-item active" href="#"><span>Link secondario 2 (attivo)</span></a>
@@ -119,7 +119,7 @@ Per creare una sidebar con linea separatrice a destra è sufficiente aggiungere 
 <div class="sidebar-wrapper it-line-right-side">
   <div class="sidebar-linklist-wrapper">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+      <ul class="link-list" role="list">
         <li>
           <h3 class="no_toc">Header</h3>
         </li>
@@ -136,7 +136,7 @@ Per creare una sidebar con linea separatrice a destra è sufficiente aggiungere 
   </div>
   <div class="sidebar-linklist-wrapper linklist-secondary">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+      <ul class="link-list" role="list">
         <li><a class="list-item" href="#"><span>Link secondario 1</span></a>
         </li>
         <li><a class="list-item active" href="#"><span>Link secondario 2 (attivo)</span></a>
@@ -158,7 +158,7 @@ Per creare una sidebar con linea separatrice a sinistra è sufficiente aggiunger
 <div class="sidebar-wrapper it-line-left-side">
   <div class="sidebar-linklist-wrapper">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+      <ul class="link-list" role="list">
         <li>
           <h3 class="no_toc">Header</h3>
         </li>
@@ -175,7 +175,7 @@ Per creare una sidebar con linea separatrice a sinistra è sufficiente aggiunger
   </div>
   <div class="sidebar-linklist-wrapper linklist-secondary">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+      <ul class="link-list" role="list">
         <li><a class="list-item" href="#"><span>Link secondario 1</span></a>
         </li>
         <li><a class="list-item active" href="#"><span>Link secondario 2 (attivo)</span></a>
@@ -198,7 +198,7 @@ La sidebar può contenere una Lista di link primaria annidata.
   <h3 class="no_toc">Header</h3>
   <div class="sidebar-linklist-wrapper">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+      <ul class="link-list" role="list">
         <li>
           <a class="list-item large medium right-icon active" href="#collapseOne" role="button" data-bs-toggle="collapse" aria-expanded="true" aria-controls="collapseOne">
           <span class="list-item-title-icon-wrapper">
@@ -206,7 +206,7 @@ La sidebar può contenere una Lista di link primaria annidata.
             <svg class="icon icon-sm icon-primary right" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-expand"></use></svg>
           </span>
           </a>
-          <ul class="link-sublist collapse show" id="collapseOne">
+          <ul class="link-sublist collapse show" id="collapseOne" role="list">
             <li><a class="list-item active" href="#"><span>Link lista 1.1 (attivo)</span></a>
             </li>
             <li><a class="list-item" href="#"><span>Link lista 1.2</span></a>
@@ -222,7 +222,7 @@ La sidebar può contenere una Lista di link primaria annidata.
               <svg class="icon icon-sm icon-primary right" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-expand"></use></svg>
             </span>
           </a>
-          <ul class="link-sublist collapse" id="collapseTwo">
+          <ul class="link-sublist collapse" id="collapseTwo" role="list">
             <li><a class="list-item" href="#"><span>Link lista 2.1</span></a>
             </li>
             <li><a class="list-item" href="#"><span>Link lista 2.2</span></a>
@@ -238,7 +238,7 @@ La sidebar può contenere una Lista di link primaria annidata.
               <svg class="icon icon-sm icon-primary right" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-expand"></use></svg>
             </span>
           </a>
-          <ul class="link-sublist collapse" id="collapseThree">
+          <ul class="link-sublist collapse" id="collapseThree" role="list">
             <li><a class="list-item" href="#"><span>Link lista 3.1</span></a>
             </li>
             <li><a class="list-item" href="#"><span>Link lista 3.2</span></a>
@@ -252,7 +252,7 @@ La sidebar può contenere una Lista di link primaria annidata.
   </div>
   <div class="sidebar-linklist-wrapper linklist-secondary">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+      <ul class="link-list" role="list">
         <li><a class="list-item" href="#"><span>Link secondario 1</span></a>
         </li>
         <li><a class="list-item active" href="#"><span>Link secondario 2 (attivo)</span></a>
@@ -275,7 +275,7 @@ Per cambiare il tema della sidebar e renderla scura è sufficiente aggiungere al
   <h3 class="no_toc">Header</h3>
   <div class="sidebar-linklist-wrapper">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+      <ul class="link-list" role="list">
         <li>
           <a class="list-item large medium right-icon active" href="#collapseFour" role="button" data-bs-toggle="collapse" aria-expanded="true" aria-controls="collapseOne">
             <span class="list-item-title-icon-wrapper">
@@ -297,7 +297,7 @@ Per cambiare il tema della sidebar e renderla scura è sufficiente aggiungere al
               <span>Link lista 2</span><svg class="icon icon-sm icon-white right" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-expand"></use></svg>
             </span>
           </a>
-          <ul class="link-sublist collapse" id="collapseFive">
+          <ul class="link-sublist collapse" id="collapseFive" role="list">
             <li><a class="list-item" href="#"><span>Link lista 2.1</span></a>
             </li>
             <li><a class="list-item" href="#"><span>Link lista 2.2</span></a>
@@ -312,7 +312,7 @@ Per cambiare il tema della sidebar e renderla scura è sufficiente aggiungere al
               <span>Link lista 3</span><svg class="icon icon-sm icon-white right" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-expand"></use></svg>
             </span>
           </a>
-          <ul class="link-sublist collapse" id="collapseSix">
+          <ul class="link-sublist collapse" id="collapseSix" role="list">
             <li><a class="list-item" href="#"><span>Link lista 3.1</span></a>
             </li>
             <li><a class="list-item" href="#"><span>Link lista 3.2</span></a>
@@ -326,7 +326,7 @@ Per cambiare il tema della sidebar e renderla scura è sufficiente aggiungere al
   </div>
   <div class="sidebar-linklist-wrapper linklist-secondary">
     <div class="link-list-wrapper">
-      <ul class="link-list">
+      <ul class="link-list" role="list">
         <li><a class="list-item" href="#"><span>Link secondario 1</span></a>
         </li>
         <li><a class="list-item active" href="#"><span>Link secondario 2 (attivo)</span></a>

--- a/docs/menu-di-navigazione/thumbnav.md
+++ b/docs/menu-di-navigazione/thumbnav.md
@@ -32,7 +32,7 @@ Per ragioni di accessibilità è importante indicare all'interno dell'attributo 
 
 {% comment %}Example name: Base{% endcomment %}
 {% capture example %}
-<ul class="thumb-nav">
+<ul class="thumb-nav" role="list">
     <li>
       <a href="#" class="active ratio ratio-3x2"><img src="https://picsum.photos/240/160?image=1056" alt="Visualizza immagine 1"></a>
     </li>
@@ -51,7 +51,7 @@ Applicando la classe `.thumb-nav-small` al contenitore `.thumb-nav` si otterrann
 
 {% comment %}Example name: Variante compatta{% endcomment %}
 {% capture example %}
-<ul class="thumb-nav thumb-nav-small">
+<ul class="thumb-nav thumb-nav-small" role="list">
     <li>
       <a href="#" class="active ratio ratio-3x2"><img src="https://picsum.photos/240/160?image=1056" alt="Visualizza immagine 1"></a>
     </li>
@@ -74,7 +74,7 @@ Utilizzare la classe `.thumb-nav-nozoom` per disabilitare l'effetto di zoom sull
 
 {% comment %}Example name: Con hover senza ingrandimento{% endcomment %}
 {% capture example %}
-<ul class="thumb-nav thumb-nav-nozoom">
+<ul class="thumb-nav thumb-nav-nozoom" role="list">
     <li>
       <a href="#" class="active ratio ratio-3x2"><img src="https://picsum.photos/240/160?image=1056" alt="Visualizza immagine 1"></a>
     </li>
@@ -93,7 +93,7 @@ Utilizzare la classe `.thumb-nav-black` per ottenere un effetto di overlay nero 
 
 {% comment %}Example name: Con hover con livello nero{% endcomment %}
 {% capture example %}
-<ul class="thumb-nav thumb-nav-black">
+<ul class="thumb-nav thumb-nav-black" role="list">
     <li>
       <a href="#" class="active ratio ratio-3x2"><img src="https://picsum.photos/240/160?image=1056" alt="Visualizza immagine 1"></a>
     </li>
@@ -112,7 +112,7 @@ Utilizzare la classe `.thumb-nav-primary` per ottenere un effetto di overlay di 
 
 {% comment %}Example name: Con hover con livello primary{% endcomment %}
 {% capture example %}
-<ul class="thumb-nav thumb-nav-primary">
+<ul class="thumb-nav thumb-nav-primary" role="list">
     <li>
       <a href="#" class="active ratio ratio-3x2"><img src="https://picsum.photos/240/160?image=1056" alt="Visualizza immagine 1"></a>
     </li>
@@ -131,7 +131,7 @@ Applicando la classe `.thumb-nav-vertical` al contenitore `.thumb-nav` si ottien
 
 {% comment %}Example name: Verticale{% endcomment %}
 {% capture example %}
-<ul class="thumb-nav thumb-nav-vertical">
+<ul class="thumb-nav thumb-nav-vertical" role="list">
     <li>
       <a href="#" class="active ratio ratio-3x2"><img src="https://picsum.photos/240/160?image=1056" alt="Visualizza immagine 1"></a>
     </li>
@@ -161,7 +161,7 @@ Alla Thumbnav dovrà essere applicata una classe a scelta fra:
 {% capture example %}
 <div class="test-gallery position-relative">
   <img src="https://picsum.photos/1280/720?image=1056" class="test-image" alt="Descrizione immagine"/>
-  <ul class="thumb-nav thumb-nav-small thumb-nav-bottom">
+  <ul class="thumb-nav thumb-nav-small thumb-nav-bottom" role="list">
       <li>
         <a href="#" class="active ratio ratio-3x2"><img src="https://picsum.photos/240/160?image=1056" alt="Visualizza immagine 1"></a>
       </li>
@@ -181,7 +181,7 @@ Alla Thumbnav dovrà essere applicata una classe a scelta fra:
 {% capture example %}
 <div class="test-gallery position-relative">
   <img src="https://picsum.photos/1280/720?image=1056" class="test-image" alt="Descrizione immagine"/>
-  <ul class="thumb-nav thumb-nav-small thumb-nav-top">
+  <ul class="thumb-nav thumb-nav-small thumb-nav-top" role="list">
       <li>
         <a href="#" class="active ratio ratio-3x2"><img src="https://picsum.photos/240/160?image=1056" alt="Visualizza immagine 1"></a>
       </li>
@@ -202,7 +202,7 @@ Alla Thumbnav dovrà essere applicata una classe a scelta fra:
 <div class="test-gallery position-relative">
   <img src="https://picsum.photos/720/720?image=1056" class="d-md-none test-image" alt="Descrizione immagine"/>
   <img src="https://picsum.photos/1280/720?image=1056" class="d-none d-md-block test-image" alt="Descrizione immagine"/>
-  <ul class="thumb-nav thumb-nav-vertical thumb-nav-small thumb-nav-left">
+  <ul class="thumb-nav thumb-nav-vertical thumb-nav-small thumb-nav-left" role="list">
       <li>
         <a href="#" class="active ratio ratio-3x2"><img src="https://picsum.photos/240/160?image=1056" alt="Visualizza immagine 1"></a>
       </li>
@@ -223,7 +223,7 @@ Alla Thumbnav dovrà essere applicata una classe a scelta fra:
 <div class="test-gallery position-relative">
   <img src="https://picsum.photos/720/720?image=1056" class="d-md-none test-image" alt="Descrizione immagine"/>
   <img src="https://picsum.photos/1280/720?image=1056" class="d-none d-md-block test-image" alt="Descrizione immagine"/>
-  <ul class="thumb-nav thumb-nav-vertical thumb-nav-small thumb-nav-right">
+  <ul class="thumb-nav thumb-nav-vertical thumb-nav-small thumb-nav-right" role="list">
       <li>
         <a href="#" class="active ratio ratio-3x2"><img src="https://picsum.photos/240/160?image=1056" alt="Visualizza immagine 1"></a>
       </li>
@@ -243,7 +243,7 @@ Applicando la classe `.thumb-nav-fixed` alla Thumbnav le thumbnail avranno una l
 
 {% comment %}Example name: Griglia a larghezza fissa{% endcomment %}
 {% capture example %}
-<ul class="thumb-nav thumb-nav-fixed">
+<ul class="thumb-nav thumb-nav-fixed" role="list">
     <li>
       <a href="#" class="ratio ratio-3x2"><img src="https://picsum.photos/240/160?image=1056" alt="Visualizza immagine 1"></a>
     </li>
@@ -276,7 +276,7 @@ Applicando la classe `.thumb-nav-auto` alla Thumbnav le thumbnail occuperanno au
 
 {% comment %}Example name: Griglia a larghezza automatica, eg. 1{% endcomment %}
 {% capture example %}
-<ul class="thumb-nav thumb-nav-auto thumb-nav-auto-3">
+<ul class="thumb-nav thumb-nav-auto thumb-nav-auto-3" role="list">
     <li>
       <a href="#" class="ratio ratio-3x2"><img src="https://picsum.photos/390/260?image=1056" alt="Visualizza immagine 1"></a>
     </li>
@@ -299,7 +299,7 @@ Applicando la classe `.thumb-nav-auto` alla Thumbnav le thumbnail occuperanno au
 
 {% comment %}Example name: Griglia a larghezza automatica, eg. 2{% endcomment %}
 {% capture example %}
-<ul class="thumb-nav thumb-nav-auto thumb-nav-auto-5">
+<ul class="thumb-nav thumb-nav-auto thumb-nav-auto-5" role="list">
     <li>
       <a href="#" class="ratio ratio-3x2"><img src="https://picsum.photos/240/160?image=1056" alt="Visualizza immagine 1"></a>
     </li>

--- a/docs/menu-di-navigazione/toolbar.md
+++ b/docs/menu-di-navigazione/toolbar.md
@@ -424,7 +424,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton2">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -441,7 +441,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton3">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -458,7 +458,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton4">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -475,7 +475,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton5">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="list-item icon-left" href="#"><svg class="icon me-2" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use></svg><span>Label</span></a></li>
               <li><a class="list-item icon-left" href="#"><svg class="icon me-2" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-mail"></use></svg><span>Label</span></a></li>
               <li><a class="list-item icon-left" href="#"><svg class="icon me-2" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-settings"></use></svg><span>Label</span></a></li>
@@ -507,7 +507,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton-med">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -528,7 +528,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton2-med">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -545,7 +545,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton3-med">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -562,7 +562,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton4-med">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -579,7 +579,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton5-med">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -596,7 +596,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton6-med">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="list-item icon-left" href="#"><svg class="icon me-2" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use></svg><span>Label</span></a></li>
               <li><a class="list-item icon-left" href="#"><svg class="icon me-2" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-mail"></use></svg><span>Label</span></a></li>
               <li><a class="list-item icon-left" href="#"><svg class="icon me-2" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-settings"></use></svg><span>Label</span></a></li>
@@ -628,7 +628,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton-sml">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -649,7 +649,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton2-sml">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -666,7 +666,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton3-sml">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -683,7 +683,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton4-sml">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -700,7 +700,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton5-sml">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -717,7 +717,7 @@ All'interno della Toolbar è possibile implementare dei pulsanti dropdown con re
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton6-sml">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="list-item left-icon" href="#"><svg class="icon icon-sm me-2 left" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use></svg><span>Label</span></a></li>
               <li><a class="list-item left-icon" href="#"><svg class="icon icon-sm me-2 left" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-mail"></use></svg><span>Label</span></a></li>
               <li><a class="list-item left-icon" href="#"><svg class="icon icon-sm me-2 left" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-settings"></use></svg><span>Label</span></a></li>
@@ -757,7 +757,7 @@ Applicando una classe aggiuntiva `.toolbar-vertical` alla Toolbar gli elementi v
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton1-vert">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -818,7 +818,7 @@ Applicando una classe aggiuntiva `.toolbar-vertical` alla Toolbar gli elementi v
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton-vert">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>
@@ -879,7 +879,7 @@ Applicando una classe aggiuntiva `.toolbar-vertical` alla Toolbar gli elementi v
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton1-vert-sml">
           <div class="link-list-wrapper">
-            <ul class="link-list">
+            <ul class="link-list" role="list">
               <li><a class="dropdown-item list-item" href="#"><span>Azione 1</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 2</span></a></li>
               <li><a class="dropdown-item list-item" href="#"><span>Azione 3</span></a></li>

--- a/docs/organizzare-i-contenuti/liste.md
+++ b/docs/organizzare-i-contenuti/liste.md
@@ -17,7 +17,7 @@ Le liste, costituite da tag `<ul>` con classe `.it-list` all'interno di un wrapp
 
 {% capture example %}
 <div class="it-list-wrapper">
-  <ul class="it-list">
+  <ul class="it-list" role="list">
     <li>
       <div class="list-item">
         <div class="it-right-zone">
@@ -50,7 +50,7 @@ L'elemento `.avatar` precede l'elemento `.it-right-zone` che contiene il testo.
 {% comment %}Example name: Base, con avatar{% endcomment %}
 {% capture example %}
 <div class="it-list-wrapper">
-  <ul class="it-list">
+  <ul class="it-list" role="list">
     <li>
       <div class="list-item">
         <div class="avatar size-lg">
@@ -92,7 +92,7 @@ L'elemento `.it-rounded-icon` con all'interno la relativa icona, precede l'eleme
 {% comment %}Example name: Base, con icona{% endcomment %}
 {% capture example %}
 <div class="it-list-wrapper">
-  <ul class="it-list">
+  <ul class="it-list" role="list">
     <li>
       <div class="list-item">
         <div class="it-rounded-icon">
@@ -143,7 +143,7 @@ L'elemento `.it-thumb` con all'interno la relativa immagine, precede l'elemento 
 {% comment %}Example name: Base, con immagine{% endcomment %}
 {% capture example %}
 <div class="it-list-wrapper">
-  <ul class="it-list">
+  <ul class="it-list" role="list">
     <li>
       <div class="list-item">
         <div class="it-thumb">
@@ -189,7 +189,7 @@ L'elemento `.icon` con all'interno la relativa icona segue l'elemento `.text` ch
 {% comment %}Example name: Azioni, con freccia{% endcomment %}
 {% capture example %}
 <div class="it-list-wrapper">
-  <ul class="it-list">
+  <ul class="it-list" role="list">
     <li>
       <a href="#" class="list-item">
         <div class="it-right-zone">
@@ -223,7 +223,7 @@ L'elemento `.it-multiple` con all'interno le relative icone, segue l'elemento `.
 {% comment %}Example name: Azioni, multiple{% endcomment %}
 {% capture example %}
 <div class="it-list-wrapper">
-  <ul class="it-list">
+  <ul class="it-list" role="list">
     <li>
       <div class="list-item">
         <div class="it-right-zone">
@@ -323,7 +323,7 @@ L'elemento `.metadata`, segue l'elemento `.text`.
 {% comment %}Example name: Con metadata{% endcomment %}
 {% capture example %}
 <div class="it-list-wrapper">
-  <ul class="it-list">
+  <ul class="it-list" role="list">
     <li>
       <div class="list-item">
         <div class="avatar size-lg">
@@ -392,7 +392,7 @@ Per avere una lista che permetta paragrafi di testo aggiuntivo per ogni elemento
 {% comment %}Example name: Con testo aggiuntivo, azioni multiple e metadata{% endcomment %}
 {% capture example %}
 <div class="it-list-wrapper">
-  <ul class="it-list">
+  <ul class="it-list" role="list">
     <li>
       <div class="list-item">
         <div class="it-right-zone">
@@ -530,7 +530,7 @@ Le liste per menu di navigazione, costituite da tag `<ul>` con classe `.link-lis
 {% comment %}Example name: Per menu, base{% endcomment %}
 {% capture example %}
 <div class="link-list-wrapper">
-  <ul class="link-list">
+  <ul class="link-list" role="list">
     <li>
       <a class="list-item" href="#"><span>Link lista 1</span></a>
     </li>
@@ -551,7 +551,7 @@ Per rendere attivo un elemento è sufficiente aggiungere la classe `.active` al 
 {% comment %}Example name: Per menu, con stato attivo{% endcomment %}
 {% capture example %}
 <div class="link-list-wrapper">
-  <ul class="link-list">
+  <ul class="link-list" role="list">
     <li>
       <a class="list-item" href="#"><span>Link lista 1</span></a>
     </li>
@@ -572,7 +572,7 @@ Per disabilitare un elemento è sufficiente aggiungere la classe `.disabled` al 
 {% comment %}Example name: Per menu, con stato disabilitato{% endcomment %}
 {% capture example %}
 <div class="link-list-wrapper">
-  <ul class="link-list">
+  <ul class="link-list" role="list">
     <li>
       <a class="list-item" href="#"><span>Link lista 1</span></a>
     </li>
@@ -597,7 +597,7 @@ Il divisore è costituito dal tag `<span>` con classe `.divider` e attributo `ro
 {% capture example %}
 <div class="link-list-wrapper">
   <h4 class="link-list-heading">Intestazione senza link</h4>
-  <ul class="link-list">
+  <ul class="link-list" role="list">
     <li>
       <a class="list-item" href="#"><span>Link lista 1</span></a>
     </li>
@@ -621,7 +621,7 @@ Il divisore è costituito dal tag `<span>` con classe `.divider` e attributo `ro
 {% capture example %}
 <div class="link-list-wrapper">
   <h4 class="link-list-heading"><a href="#">Intestazione con link</a></h4>
-  <ul class="link-list">
+  <ul class="link-list" role="list">
     <li>
       <a class="list-item" href="#"><span>Link lista 1</span></a>
     </li>
@@ -649,7 +649,7 @@ Per ogni elemento di una lista di link è possibile definire una variante di dim
 {% capture example %}
 <div class="link-list-wrapper">
   <h4 class="link-list-heading">Intestazione</h4>
-  <ul class="link-list">
+  <ul class="link-list" role="list">
     <li>
       <a class="list-item large" href="#"><span>Link lista 1</span></a>
     </li>
@@ -683,7 +683,7 @@ All'interno del tag `<span class="list-item-title-icon-wrapper">` subito dopo lo
 {% comment %}Example name: Per menu, multilinea con icona{% endcomment %}
 {% capture example %}
 <div class="link-list-wrapper multiline">
-  <ul class="link-list">
+  <ul class="link-list" role="list">
     <li>
       <a class="list-item active icon-right" href="#">
         <span class="list-item-title-icon-wrapper">
@@ -749,7 +749,7 @@ Per posizionare correttamente l'icona a sinistra del testo bisogna aggiungere al
 {% comment %}Example name: Per menu, con controlli e icona a sinistra{% endcomment %}
 {% capture example %}
 <div class="link-list-wrapper">
-  <ul class="link-list">
+  <ul class="link-list" role="list">
     <li>
       <a class="list-item active icon-left" href="#">
         <span class="list-item-title-icon-wrapper">
@@ -797,7 +797,7 @@ Per posizionare correttamente l'icona a destra del testo bisogna aggiungere al t
 {% comment %}Example name: Per menu, con controlli e icona a destra{% endcomment %}
 {% capture example %}
 <div class="link-list-wrapper">
-  <ul class="link-list">
+  <ul class="link-list" role="list">
     <li>
       <a class="list-item active icon-right" href="#">
         <span class="list-item-title-icon-wrapper">
@@ -850,7 +850,7 @@ Inserisci l'icona all'interno del tag `<span class="list-item-title-icon-wrapper
 {% comment %}Example name: Per menu, con azioni primaria e secondaria, varianti posizione icona{% endcomment %}
 {% capture example %}
 <div class="link-list-wrapper">
-  <ul class="link-list">
+  <ul class="link-list" role="list">
     <li>
       <a class="list-item active icon-left" href="#">
         <span class="list-item-title-icon-wrapper">
@@ -895,7 +895,7 @@ Una lista di link può contenere anche elementi appartenenti ai form, di seguito
 {% comment %}Example name: Lista di link, con toggle{% endcomment %}
 {% capture example %}
  <div class="link-list-wrapper">
-  <ul class="link-list">
+  <ul class="link-list" role="list">
     <li>
       <div class="toggles">
         <label for="toggle1">Label per toggle
@@ -921,7 +921,7 @@ Lista di link contenente un [checkbox]({{ site.baseurl }}/docs/form/checkbox/).
 {% comment %}Example name: Lista di link, con checkbox{% endcomment %}
 {% capture example %}
 <div class="link-list-wrapper">
-  <ul class="link-list">
+  <ul class="link-list" role="list">
     <li>
       <div class="form-check form-check-group" aria-describedby="">
         <input type="checkbox" id="checkbox6" checked>
@@ -955,7 +955,7 @@ Di seguito un esempio di navigazione annidata espansa.
 {% comment %}Example name: Per menu, annidata espansa{% endcomment %}
 {% capture example %}
 <div class="link-list-wrapper">
-  <ul class="link-list">
+  <ul class="link-list" role="list">
     <li>
       <a class="list-item large medium icon-right" href="#">
         <span class="list-item-title-icon-wrapper">
@@ -977,7 +977,7 @@ Di seguito un esempio di navigazione annidata espansa.
           </svg>
         </span>
       </a>
-      <ul class="link-sublist" id="">
+      <ul class="link-sublist" id="" role="list">
         <li><a class="list-item" href="#"><span>Link lista 1</span></a>
         </li>
         <li><a class="list-item" href="#"><span>Link lista 2</span></a>
@@ -1009,7 +1009,7 @@ Per questo tipo di link list sono state utilizzate, oltre alle classi custom, le
 {% comment %}Example name: Per menu, annidata collassabile{% endcomment %}
 {% capture example %}
 <div class="link-list-wrapper">
-  <ul class="link-list">
+  <ul class="link-list" role="list">
     <li>
       <a class="list-item large medium icon-right" href="#collapseOne" role="button" data-bs-toggle="collapse" aria-expanded="false" aria-controls="collapseOne">
         <span class="list-item-title-icon-wrapper">
@@ -1017,7 +1017,7 @@ Per questo tipo di link list sono state utilizzate, oltre alle classi custom, le
           <svg class="icon icon-primary"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-expand"></use></svg>
         </span>
       </a>
-      <ul class="link-sublist collapse" id="collapseOne">
+      <ul class="link-sublist collapse" id="collapseOne" role="list">
         <li><a class="list-item" href="#"><span>Link lista 1</span></a>
         </li>
         <li><a class="list-item" href="#"><span>Link lista 1</span></a>
@@ -1033,7 +1033,7 @@ Per questo tipo di link list sono state utilizzate, oltre alle classi custom, le
           <svg class="icon icon-primary"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-expand"></use></svg>
         </span>
       </a>
-      <ul class="link-sublist collapse" id="collapseTwo">
+      <ul class="link-sublist collapse" id="collapseTwo" role="list">
         <li><a class="list-item" href="#"><span>Link lista 1</span></a>
         </li>
         <li><a class="list-item" href="#"><span>Link lista 1</span></a>
@@ -1049,7 +1049,7 @@ Per questo tipo di link list sono state utilizzate, oltre alle classi custom, le
           <svg class="icon icon-primary"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-expand"></use></svg>
         </span>
       </a>
-      <ul class="link-sublist collapse" id="collapseThree">
+      <ul class="link-sublist collapse" id="collapseThree" role="list">
         <li><a class="list-item" href="#"><span>Link lista 1</span></a>
         </li>
         <li><a class="list-item" href="#"><span>Link lista 1</span></a>

--- a/docs/organizzare-i-contenuti/tipografia.md
+++ b/docs/organizzare-i-contenuti/tipografia.md
@@ -363,13 +363,13 @@ per tutti gli elenchi annidati.
 
 {% comment %}Example name: Lista senza stile{% endcomment %}
 {% capture example %}
-<ul class="list-unstyled">
+<ul class="list-unstyled" role="list">
   <li>Lorem ipsum dolor sit amet</li>
   <li>Consectetur adipiscing elit</li>
   <li>Integer molestie lorem at massa</li>
   <li>Facilisis in pretium nisl aliquet</li>
   <li>Nulla volutpat aliquam velit
-    <ul class="list-unstyled">
+    <ul class="list-unstyled" role="list">
       <li>Phasellus iaculis neque</li>
       <li>Purus sodales ultricies</li>
       <li>Vestibulum laoreet porttitor sem</li>
@@ -389,7 +389,7 @@ combinazione di due classi, `.list-inline` e `.list-inline-item`.
 
 {% comment %}Example name: Lista inline{% endcomment %}
 {% capture example %}
-<ul class="list-inline">
+<ul class="list-inline" role="list">
   <li class="list-inline-item">Lorem ipsum</li>
   <li class="list-inline-item">Phasellus iaculis</li>
   <li class="list-inline-item">Nulla volutpat</li>


### PR DESCRIPTION
## Cosa
Fix #1692 (alternativa alla PR #1743)

Questa PR implementa una soluzione alternativa a quella proposta da @deodorhunter (PR #1743: `font-size: 0` sul `li::marker`, rimuovendo `list-style-type: none`) per quanto riguarda **BSI v2.** 

Questa soluzione aggiunge `role="list"` agli elementi `<ul>` che non sono contenuti in elementi `<nav>`, come da indicazioni MDN https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/list-style#accessibility. 

Dobbiamo fare review con calma in tutte le combinazioni di OS/Browser/SR in tutti **i componenti i cui markup sono stati toccati direttamente** (vedi tab "Files changed"). Bisogna verificare resa e testarne funzionamento prima di integrare questa soluzione.  

**Dovremo poi se funziona riportare la soluzione sul ramo 3.x.**

**Da evidenziare che risulta una breaking change di tutti i componenti toccati dalla PR, da documentare in caso come tale.**

**Da verificare inoltre se serve aggiungere contenuti in alcuni dei callout Accessibilità dei diversi componenti**. 

## Perché 
A causa di un comportamento noto di WebKit (introdotto nel 2020), l'applicazione di `list-style-type: none;` rimuove la natura di "lista" per le tecnologie assistive. Di conseguenza, su Safari + VoiceOver (macOS/iOS), le liste non vengono annunciate come tali e gli item vengono letti in sequenza senza indicare il conteggio o la posizione.

## Altro
Seppur preferirei non toccare il markup e trovare una soluzione solo `scss` come quella della PR #1743, dai primi test questo fix mi pare molto più solido e robusto in tutte le situazioni e combinazioni. 

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
