### PR TITLE
fix: replace shadow with border color 

### DIFF
--- a/src/scss/components/_headernavbartheme.scss
+++ b/src/scss/components/_headernavbartheme.scss
@@ -116,7 +116,7 @@
   .it-header-navbar-wrapper {
     &.theme-light-desk {
       background: $navigation-light-bg-color;
-      box-shadow: $dropdown-box-shadow;
+      border-bottom: 1px solid rgba($header-slim-theme-light-text-color, 0.2);
       .navbar .navbar-collapsable .navbar-nav li a.nav-link.dropdown-toggle svg {
         fill: $navigation-light-text-color;
       }


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Corregge #1597, sostituendo `box-shadow` con colore del bordo usato in header slim.

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
