### PR TITLE
fix: tab bottom border

### DIFF
--- a/docs/componenti/tab.md
+++ b/docs/componenti/tab.md
@@ -336,12 +336,6 @@ Se i tab contengono icone è necessario aggiungere un'ulteriore classe al wrappe
         Tab 6
       </a>
     </li>
-    <li class="nav-item">
-      <a class="nav-link">
-        <svg class="icon"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-link"></use></svg>
-        Tab 7
-      </a>
-    </li>
   </ul>
 </div>
 {% endcapture %}{% include example.html content=example %}

--- a/src/scss/components/_tab.scss
+++ b/src/scss/components/_tab.scss
@@ -50,6 +50,8 @@
   flex-wrap: nowrap;
   overflow-x: auto;
   overflow-y: hidden;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
   border-bottom-color: var(--#{$prefix}tabs-border-color);
   background-color: var(--#{$prefix}tabs-background-color);
   -webkit-overflow-scrolling: touch;
@@ -356,6 +358,8 @@
 .flex-column-reverse {
   .nav-tabs {
     border-top-width: 1px;
+    border-top-style: solid;
+    border-top-color: var(--#{$prefix}color-border-subtle);
     border-bottom-width: 0; // reset bottom border
 
     .nav-link {


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Fix #1793 

Corretta anche la preview delle tab senza scroll.

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
