### PR TITLE
fix: input group border

### DIFF
--- a/docs/form/input.md
+++ b/docs/form/input.md
@@ -98,14 +98,13 @@ Il testo di aiuto deve essere esplicitamente associato ai campi a cui si riferis
   <label class="active" for="input-group-2">Campo con icona e segnaposto</label>
   <div class="input-group">
     <span class="input-group-text"><svg class="icon icon-sm icon-secondary" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pencil"></use></svg></span>
-    <input type="text" class="form-control" id="input-group-2" name="input-group-2" placeholder="Lorem Ipsum">
+    <input type="text" class="form-control" id="input-group-2" name="input-group-2" placeholder="Testo segnaposto">
   </div>
 </div>
 <div class="form-group">
-  <label for="input-group-3">Campo con icona e pulsante</label>
+  <label for="input-group-3">Campo con pulsante di invio e segnaposto</label>
   <div class="input-group">
-      <span class="input-group-text"><svg class="icon icon-sm icon-secondary" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pencil"></use></svg></span>
-      <input type="text" class="form-control" id="input-group-3" name="input-group-3">
+      <input type="text" class="form-control" id="input-group-3" name="input-group-3" placeholder="Testo segnaposto">
       <div class="input-group-append">
         <button class="btn btn-primary" type="button" id="button-4">Invio</button>
       </div>

--- a/src/scss/forms/_form-input-number.scss
+++ b/src/scss/forms/_form-input-number.scss
@@ -123,13 +123,6 @@
   }
 }
 
-// Reset border when input is prepended with input-group-text
-// input[type='number'] {
-//   .input-number .input-group-text + & {
-//     border-left: 0;
-//   }
-// }
-
 //Desktop
 @include media-breakpoint-up(xl) {
   .input-number {

--- a/src/scss/forms/_form-input-number.scss
+++ b/src/scss/forms/_form-input-number.scss
@@ -124,11 +124,11 @@
 }
 
 // Reset border when input is prepended with input-group-text
-input[type='number'] {
-  .input-number .input-group-text + & {
-    border-left: 0;
-  }
-}
+// input[type='number'] {
+//   .input-number .input-group-text + & {
+//     border-left: 0;
+//   }
+// }
 
 //Desktop
 @include media-breakpoint-up(xl) {

--- a/src/scss/forms/_input-group.scss
+++ b/src/scss/forms/_input-group.scss
@@ -16,8 +16,8 @@
   align-items: stretch;
   width: 100%;
 
-  // Reset border
-  > input {
+  // Reset border when input is prepended with input-group-text
+  > .input-group-text + input {
     border-left-width: 0;
   }
 


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Corregge il bug segnalato in #1810, rendendo la regola già presente in `form-input-number` valida per tutte le tipologie di input.

Da rilasciare al più presto per fix su Dev Kit.

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
