### PR TITLE
feat: esponi CSS custom properties mancanti per 6 componenti

### DIFF
--- a/src/scss/components/_bottomnav.scss
+++ b/src/scss/components/_bottomnav.scss
@@ -12,9 +12,6 @@
 // Properties
 //
 
-// Styles
-//
-
 .bottom-nav {
   --#{$prefix}bottom-nav-height: 96px;
   --#{$prefix}bottom-nav-list-height: 64px;
@@ -39,7 +36,12 @@
   --#{$prefix}bottom-nav-shadow-opacity: 0.18;
   --#{$prefix}bottom-nav-shadow-transform: translateY(-50%) scalex(1.4) scaleY(0.12);
   --#{$prefix}bottom-nav-shadow-background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0) 60%);
+}
 
+// Styles
+//
+/* stylelint-disable-next-line no-duplicate-selectors */
+.bottom-nav {
   position: fixed;
   bottom: 0;
   left: 0;

--- a/src/scss/components/_list-group.scss
+++ b/src/scss/components/_list-group.scss
@@ -19,13 +19,6 @@
 // Properties
 //
 
-// Styles
-//
-
-// Base class
-//
-// Easily usable on <ul>, <ol>, or <div>.
-
 .list-group {
   --#{$prefix}list-group-action-active-bg: #{$list-group-action-active-bg};
   --#{$prefix}list-group-action-active-color: #{$list-group-action-active-color};
@@ -44,7 +37,16 @@
   --#{$prefix}list-group-disabled-color: #{$list-group-disabled-color};
   --#{$prefix}list-group-item-padding-x: #{$list-group-item-padding-x};
   --#{$prefix}list-group-item-padding-y: #{$list-group-item-padding-y};
+}
 
+// Styles
+//
+
+// Base class
+//
+// Easily usable on <ul>, <ol>, or <div>.
+/* stylelint-disable-next-line no-duplicate-selectors */
+.list-group {
   display: flex;
   flex-direction: column;
 

--- a/src/scss/components/_notifications.scss
+++ b/src/scss/components/_notifications.scss
@@ -13,9 +13,6 @@
 // Properties
 //
 
-// Styles
-//
-
 .notification {
   --#{$prefix}notification-background: var(--#{$prefix}color-background-inverse);
   --#{$prefix}notification-border-color: var(--#{$prefix}color-border-subtle);
@@ -35,6 +32,8 @@
   }
 }
 
+// Styles
+//
 /* stylelint-disable-next-line no-duplicate-selectors */
 .notification {
   position: fixed;

--- a/src/scss/components/_offcanvas.scss
+++ b/src/scss/components/_offcanvas.scss
@@ -17,11 +17,7 @@
 // Properties
 //
 
-// Styles
-//
-
 // stylelint-disable function-disallowed-list
-
 %offcanvas-css-vars {
   // scss-docs-start offcanvas-css-vars
   --#{$prefix}offcanvas-zindex: #{$zindex-offcanvas};
@@ -36,6 +32,9 @@
   --#{$prefix}offcanvas-box-shadow: #{$offcanvas-box-shadow};
   // scss-docs-end offcanvas-css-vars
 }
+
+// Styles
+//
 
 @each $breakpoint in map.keys($grid-breakpoints) {
   $next: breakpoint-next($breakpoint, $grid-breakpoints);

--- a/src/scss/components/_popover.scss
+++ b/src/scss/components/_popover.scss
@@ -17,6 +17,29 @@
 // Properties
 //
 
+.popover {
+    --#{$prefix}popover-arrow-border: var(--#{$prefix}popover-border-color);
+  --#{$prefix}popover-arrow-height: #{$popover-arrow-height};
+  --#{$prefix}popover-arrow-width: #{$popover-arrow-width};
+  --#{$prefix}popover-body-color: #{$popover-body-color};
+  --#{$prefix}popover-body-padding-x: #{$popover-body-padding-x};
+  --#{$prefix}popover-body-padding-y: #{$popover-body-padding-y};
+  --#{$prefix}popover-bg: #{$popover-bg};
+  --#{$prefix}popover-box-shadow: #{$popover-box-shadow};
+  --#{$prefix}popover-border-color: #{$popover-border-color};
+  --#{$prefix}popover-border-radius: #{$popover-border-radius};
+  --#{$prefix}popover-border-width: #{$popover-border-width};
+  @include rfs($popover-font-size, --#{$prefix}popover-font-size);
+  --#{$prefix}popover-header-bg: #{$popover-header-bg};
+  --#{$prefix}popover-header-color: #{$popover-header-color};
+  @include rfs($popover-header-font-size, --#{$prefix}popover-header-font-size);
+  --#{$prefix}popover-header-padding-x: #{$popover-header-padding-x};
+  --#{$prefix}popover-header-padding-y: #{$popover-header-padding-y};
+  --#{$prefix}popover-inner-border-radius: #{$popover-inner-border-radius};
+  --#{$prefix}popover-max-width: #{$popover-max-width};
+  --#{$prefix}popover-zindex: #{$zindex-popover};
+}
+
 // Styles
 //
 
@@ -160,28 +183,8 @@
   color: var(--#{$prefix}popover-body-color);
 }
 
+/* stylelint-disable-next-line no-duplicate-selectors */
 .popover {
-  --#{$prefix}popover-arrow-border: var(--#{$prefix}popover-border-color);
-  --#{$prefix}popover-arrow-height: #{$popover-arrow-height};
-  --#{$prefix}popover-arrow-width: #{$popover-arrow-width};
-  --#{$prefix}popover-body-color: #{$popover-body-color};
-  --#{$prefix}popover-body-padding-x: #{$popover-body-padding-x};
-  --#{$prefix}popover-body-padding-y: #{$popover-body-padding-y};
-  --#{$prefix}popover-bg: #{$popover-bg};
-  --#{$prefix}popover-box-shadow: #{$popover-box-shadow};
-  --#{$prefix}popover-border-color: #{$popover-border-color};
-  --#{$prefix}popover-border-radius: #{$popover-border-radius};
-  --#{$prefix}popover-border-width: #{$popover-border-width};
-  @include rfs($popover-font-size, --#{$prefix}popover-font-size);
-  --#{$prefix}popover-header-bg: #{$popover-header-bg};
-  --#{$prefix}popover-header-color: #{$popover-header-color};
-  @include rfs($popover-header-font-size, --#{$prefix}popover-header-font-size);
-  --#{$prefix}popover-header-padding-x: #{$popover-header-padding-x};
-  --#{$prefix}popover-header-padding-y: #{$popover-header-padding-y};
-  --#{$prefix}popover-inner-border-radius: #{$popover-inner-border-radius};
-  --#{$prefix}popover-max-width: #{$popover-max-width};
-  --#{$prefix}popover-zindex: #{$zindex-popover};
-
   z-index: var(--#{$prefix}popover-zindex);
   display: block;
   max-width: var(--#{$prefix}popover-max-width);

--- a/src/scss/components/_thumbnav.scss
+++ b/src/scss/components/_thumbnav.scss
@@ -12,9 +12,6 @@
 // Properties
 //
 
-// Styles
-//
-
 .thumb-nav {
   --#{$prefix}thumb-nav-gap: var(--#{$prefix}spacing-xxs); // Controls the spacing between thumb items, using spacing tokens.
   --#{$prefix}thumb-nav-auto-basis-offset: var(--#{$prefix}spacing-s); // Controls the offset subtracted from auto layout item widths, using spacing tokens.
@@ -28,7 +25,12 @@
   --#{$prefix}thumb-nav-transition-duration: 0.4s; // Controls the base transition duration for overlay and image transform.
   --#{$prefix}thumb-nav-transition-duration-hover: 1s; // Controls the transition duration applied during hover state.
   --#{$prefix}thumb-nav-transition-easing: cubic-bezier(0.15, 0.7, 0.36, 0.99); // Controls the easing curve used by thumb-nav transitions.
+}
 
+// Styles
+//
+/* stylelint-disable-next-line no-duplicate-selectors */
+.thumb-nav {
   display: flex;
   justify-content: center;
   margin: 0 calc(var(--#{$prefix}thumb-nav-gap) * -1);


### PR DESCRIPTION
## Cosa 

Alcuni componenti avevano CSS custom properties strutturate correttamente 
ma dichiarate inline nella root della classe invece che nella sezione `// Properties` — 
e quindi non estratte da `extract_custom_properties.py` e assenti da `custom_properties.json`.

- Componenti aggiornati: bottomnav, list-group, notifications, offcanvas, popover, thumbnav.
- `custom_properties.json` verificato con generazione locale: da 524 → a 618 custom properties (+94)
- Altri componenti con properties potenzialmente non esposti discussi in issue #1822.

## Checklist:

- [x] Il codice è coerente con le indicazioni di progetto