### PR TITLE
fix: carousel arrows top position

### DIFF
--- a/src/scss/components/_carousel.scss
+++ b/src/scss/components/_carousel.scss
@@ -31,6 +31,7 @@
   --#{$prefix}carousel-pagination-dot-size: 1rem; // Controls the dot size for carousel pagination, using spacing tokens
   --#{$prefix}carousel-pagination-dot-color: var(--#{$prefix}color-background-subtle); // Controls the dot color for carousel pagination.
   --#{$prefix}carousel-pagination-spacing: var(--#{$prefix}spacing-m); // Controls the spacing around pagination dots, using spacing tokens
+  --#{$prefix}carousel-pagination-height: var(--#{$prefix}carousel-pagination-dot-size); // Controls the pagination height, used for arrow vertical alignment
   --#{$prefix}carousel-track-padding-top: var(--#{$prefix}spacing-m); // Controls the track top padding, using spacing tokens.
 }
 
@@ -143,7 +144,7 @@
   &.it-carousel-landscape-abstract-three-cols-arrow-visible {
     .splide__arrows {
       position: absolute;
-      top: 50%;
+      top: calc(50% - var(--#{$prefix}carousel-pagination-height));
       right: calc(-1 * var(--#{$prefix}carousel-arrow-offset));
       left: calc(-1 * var(--#{$prefix}carousel-arrow-offset));
       z-index: 1;


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Corregge il calcolo del valore `top` per le frecce di navigazione del carousel, calcolando anche l'altezza dell'elemento di paginazione.

Risolve #1824 

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
