### PR TITLE
fix: list spacing and examples

### DIFF
--- a/docs/organizzare-i-contenuti/liste.md
+++ b/docs/organizzare-i-contenuti/liste.md
@@ -897,17 +897,25 @@ Una lista di link può contenere anche elementi appartenenti ai form, di seguito
  <div class="link-list-wrapper">
   <ul class="link-list">
     <li>
-      <div class="toggles">
-        <label for="toggle1">Label per toggle
-          <input type="checkbox" id="toggle1"><span class="lever"></span>
-        </label>
+      <div class="form-check">
+        <div class="toggles">
+          <label for="toggleEsempio3a">
+            Label toggle 1
+            <input type="checkbox" id="toggleEsempio3a">
+            <span class="lever"></span>
+          </label>
+        </div>
       </div>
     </li>
     <li>
-      <div class="toggles">
-        <label for="toggle2">Label per toggle disabilitato
-          <input type="checkbox" id="toggle2" disabled aria-disabled="true"><span class="lever"></span>
-        </label>
+      <div class="form-check">
+        <div class="toggles">
+          <label for="toggleEsempio3b">
+            Label toggle 2
+            <input type="checkbox" id="toggleEsempio3b">
+            <span class="lever"></span>
+          </label>
+        </div>
       </div>
     </li>
   </ul>

--- a/src/scss/components/_linklist.scss
+++ b/src/scss/components/_linklist.scss
@@ -257,13 +257,6 @@
   }
 }
 
-@include media-breakpoint-up(md) {
-  .link-list-wrapper ul li a.large.icon-left,
-  .link-list-wrapper ul li a.large.icon-right {
-    --#{$prefix}linklist-item-spacing: var(--#{$prefix}spacing-s);
-  }
-}
-
 //
 // Dark theme styles
 


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Corregge spaziatura di liste per menu di navigazione collassabili ed esempio di lista con toggle. Risolve #1843 

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
