### PR TITLE
fix: Form validation styles

### DIFF
--- a/docs/esempi/form/index.html
+++ b/docs/esempi/form/index.html
@@ -330,6 +330,27 @@ title: Validazione Form
         </div>
       </div>
     </div>
+
+    <div class="row mb-4 mt-5">
+      <div class="col-12">
+        <h2>Password</h2>
+      </div>
+    </div>
+
+    <div class="row mb-4">
+      <div class="col-12 col-md-6">
+        <div class="form-group">
+          <label for="password">Password</label>
+          <input type="password" data-bs-input class="form-control input-password" id="password" aria-describedby="infoPassword2" />
+          <button type="button" class="password-icon btn" role="switch" aria-checked="false">
+            <span class="visually-hidden">Mostra/Nascondi Password</span>
+            <svg class="password-icon-visible icon icon-sm" aria-hidden="true"><use href="/dist/svg/sprites.svg#it-password-visible"></use></svg>
+            <svg class="password-icon-invisible icon icon-sm d-none" aria-hidden="true"><use href="/dist/svg/sprites.svg#it-password-invisible"></use></svg>
+          </button>
+          <p id="infoPassword2" class="form-text text-muted d-block small pb-0">Inserisci almeno 8 caratteri e alcuni caratteri speciali.</p>
+        </div>
+      </div>
+    </div>
     <div class="row">
       <div class="col-12">
         <button class="btn btn-primary mt-3" type="submit">Invia form</button>
@@ -454,6 +475,17 @@ title: Validazione Form
           rule: 'maxLength',
           value: 5,
           errorMessage: 'Inserire 5 cifre',
+        },
+      ])
+      .addField('#password', [
+        {
+          rule: 'required',
+          errorMessage: 'Questo campo è richiesto',
+        },
+        {
+          rule: 'minLength',
+          value: 8,
+          errorMessage: 'Inserire almeno 8 caratteri',
         },
       ])
       .addField('#email', [

--- a/docs/esempi/form/index.html
+++ b/docs/esempi/form/index.html
@@ -21,6 +21,7 @@ title: Validazione Form
         <div class="form-group">
           <label for="campoTesto">Campo testo</label>
           <input type="text" class="form-control" id="campoTesto" placeholder="Inserisci un testo" required />
+          <small id="campoTestoHelpDescription" class="form-text">Testo di supporto</small>
         </div>
       </div>
       <div class="col-12 col-md-4">
@@ -29,12 +30,12 @@ title: Validazione Form
           <span class="input-group input-number">
             <input type="number" data-bs-input class="form-control" id="age" min="18" max="50" step="1" required />
             <span class="input-group-text align-buttons flex-column">
-                <button class="input-number-add">
-                  <span class="visually-hidden">Aumenta valore Euro</span>
-                </button>
-                <button class="input-number-sub">
-                  <span class="visually-hidden">Diminuisci valore Euro</span>
-                </button>
+              <button class="input-number-add">
+                <span class="visually-hidden">Aumenta valore Euro</span>
+              </button>
+              <button class="input-number-sub">
+                <span class="visually-hidden">Diminuisci valore Euro</span>
+              </button>
             </span>
           </span>
         </div>
@@ -45,12 +46,12 @@ title: Validazione Form
           <span class="input-group input-number">
             <input type="number" data-bs-input class="form-control" id="camponumerico" maxlenght="5" required />
             <span class="input-group-text align-buttons flex-column">
-                <button class="input-number-add">
-                  <span class="visually-hidden">Aumenta valore Euro</span>
-                </button>
-                <button class="input-number-sub">
-                  <span class="visually-hidden">Diminuisci valore Euro</span>
-                </button>
+              <button class="input-number-add">
+                <span class="visually-hidden">Aumenta valore Euro</span>
+              </button>
+              <button class="input-number-sub">
+                <span class="visually-hidden">Diminuisci valore Euro</span>
+              </button>
             </span>
           </span>
         </div>
@@ -131,9 +132,11 @@ title: Validazione Form
       <div class="col-12">
         <div class="form-group">
           <label class="active" for="etichetta_input_group_1">Input group lg</label>
-          <div class="input-group input-group-lg">
-            <span class="input-group-text"><svg class="icon icon-sm"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pencil"></use></svg></span>
-            <input type="text" class="form-control" id="etichetta_input_group_1" name="etichetta_input_group_1" placeholder="Lorem Ipsum">
+          <div class="input-group">
+            <span class="input-group-text"
+              ><svg class="icon icon-sm"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pencil"></use></svg
+            ></span>
+            <input type="text" class="form-control form-control-lg" id="etichetta_input_group_1" name="etichetta_input_group_1" placeholder="Lorem Ipsum" />
           </div>
         </div>
       </div>
@@ -143,8 +146,10 @@ title: Validazione Form
         <div class="form-group">
           <label class="active" for="etichetta_input_group_2">Input group sm</label>
           <div class="input-group input-group-sm">
-            <span class="input-group-text"><svg class="icon icon-sm"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pencil"></use></svg></span>
-            <input type="text" class="form-control" id="etichetta_input_group_2" name="etichetta_input_group_2" placeholder="Lorem Ipsum">
+            <span class="input-group-text"
+              ><svg class="icon icon-sm"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-pencil"></use></svg
+            ></span>
+            <input type="text" class="form-control form-control-sm" id="etichetta_input_group_2" name="etichetta_input_group_2" placeholder="Lorem Ipsum" />
           </div>
         </div>
       </div>
@@ -164,25 +169,23 @@ title: Validazione Form
     </div>
     <div class="row">
       <div class="col-12 col-md-4">
-         <div class="form-group">
+        <div class="form-group">
           <label class="active" for="input-text-lg">Grande</label>
-          <input type="text" class="form-control form-control-lg" id="input-text-lg" placeholder="Inserisci il tuo nome">
+          <input type="text" class="form-control form-control-lg" id="input-text-lg" placeholder="Inserisci il tuo nome" />
         </div>
       </div>
       <div class="col-12 col-md-4">
         <div class="form-group">
           <label class="active" for="input-text-normal">Normale</label>
-          <input type="text" class="form-control" id="input-text-normal" placeholder="Inserisci il tuo nome">
+          <input type="text" class="form-control" id="input-text-normal" placeholder="Inserisci il tuo nome" />
         </div>
       </div>
       <div class="col-12 col-md-4">
         <div class="form-group">
           <label class="active" for="input-text-sm">Piccolo</label>
-          <input type="text" class="form-control form-control-sm" id="input-text-sm" placeholder="Inserisci il tuo nome">
+          <input type="text" class="form-control form-control-sm" id="input-text-sm" placeholder="Inserisci il tuo nome" />
         </div>
       </div>
-
-
     </div>
 
     <div class="row mb-4">
@@ -194,11 +197,27 @@ title: Validazione Form
     <div class="row mb-4">
       <div class="col-12 col-md-4">
         <div class="form-group">
-          <label for="accessibleAutocomplete">Comune di residenza</label>
-          <div id="accessibleAutocompleteWrapper" class="autocomplete-wrapper"></div>
+          <label for="autocomplete">Comune di residenza</label>
+          <div id="autocompleteWrapper" class="autocomplete-wrapper"></div>
         </div>
       </div>
     </div>
+
+    <div class="row mb-4">
+      <div class="col-12">
+        <h2>Textarea</h2>
+      </div>
+    </div>
+
+    <div class="row mb-4">
+      <div class="col-12 col-md-4">
+        <div class="form-group">
+          <label for="textarea">Esempio di area di testo</label>
+          <textarea class="form-control" id="textarea" rows="3"></textarea>
+        </div>
+      </div>
+    </div>
+
     <div class="row mb-4">
       <div class="col-12">
         <h2>Checkbox / Radio</h2>
@@ -227,7 +246,7 @@ title: Validazione Form
     <div class="row mb-4">
       <div class="col-12 col-md-4">
         <fieldset id="radiogroup">
-          <legend>Fieldset radio buttons</legend>
+          <legend>Fieldset radio buttons orizzontale</legend>
           <div class="form-check form-check-inline">
             <input name="gruppo2" type="radio" id="radio1" required />
             <label for="radio1">Radio 1</label>
@@ -251,6 +270,45 @@ title: Validazione Form
           </div>
         </fieldset>
       </div>
+    </div>
+    <div class="row mb-4">
+      <fieldset class="col-12 col-md-6" id="radiogroup-vertical">
+        <legend>Gruppo di radio</legend>
+        <div class="form-check form-check-group">
+          <input name="gruppo5" type="radio" id="radio13" aria-describedby="radio13-help" />
+          <label for="radio13">Opzione 1</label>
+          <small id="radio13-help" class="form-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas molestie libero</small>
+        </div>
+        <div class="form-check form-check-group">
+          <input name="gruppo5" type="radio" id="radio14" aria-describedby="radio14-help" />
+          <label for="radio14">Opzione 2</label>
+          <small id="radio14-help" class="form-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas molestie libero</small>
+        </div>
+        <div class="form-check form-check-group">
+          <input name="gruppo5" type="radio" id="radio15" aria-describedby="radio15-help" disabled="disabled" />
+          <label for="radio15" class="disabled">Opzione 3</label>
+          <small id="radio15-help" class="form-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas molestie libero</small>
+        </div>
+      </fieldset>
+
+      <fieldset class="col-12 col-md-6" id="checkboxgroup-vertical">
+        <legend>Gruppo di checkbox</legend>
+        <div class="form-check form-check-group">
+          <input id="checkbox9" type="checkbox" aria-describedby="checkbox9-help" />
+          <label for="checkbox9">Checkbox selezionato</label>
+          <small id="checkbox9-help" class="form-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas molestie libero</small>
+        </div>
+        <div class="form-check form-check-group">
+          <input id="checkbox10" type="checkbox" aria-describedby="checkbox10-help" />
+          <label for="checkbox10">Checkbox non selezionato</label>
+          <small id="checkbox10-help" class="form-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas molestie libero</small>
+        </div>
+        <div class="form-check form-check-group">
+          <input id="checkbox11" type="checkbox" aria-describedby="checkbox11-help" disabled="disabled" />
+          <label for="checkbox11" class="disabled">Checkbox disabilitato non selezionato</label>
+          <small id="checkbox11-help" class="form-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas molestie libero</small>
+        </div>
+      </fieldset>
     </div>
 
     <div class="row mb-4 mt-5">
@@ -292,43 +350,45 @@ title: Validazione Form
       '<div class="alert alert-danger alert-dismissible fade show" role="alert"><strong>Attenzione</strong> Alcuni campi inseriti sono da controllare.<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Chiudi avviso"></div>'
     const errorWrapper = document.querySelector('#errorMsgContainer')
     const validate = new bootstrap.FormValidate('#justValidate', {
-      errorFieldCssClass: 'is-invalid',
-      errorLabelCssClass: 'form-feedback',
-      errorLabelStyle: '',
-      focusInvalidField: false,
+      focusInvalidField: true,
     })
 
-    const comuniJson = await (await fetch('./comuni.json')).json();
-    const comuni = comuniJson.map(comune => comune.comune)
-    const selectAutocompleteWrapper = document.querySelector('#accessibleAutocompleteWrapper');
+    const comuniJson = await (await fetch('./comuni.json')).json()
+    const comuni = comuniJson.map((comune) => comune.comune)
+    const selectAutocompleteWrapper = document.querySelector('#autocompleteWrapper')
     const selectAutocomplete = new bootstrap.SelectAutocomplete(selectAutocompleteWrapper, {
       source: comuni,
-      id: 'accessibleAutocomplete',
+      id: 'autocomplete',
       name: 'comune-residenza',
       minLength: 3,
       onConfirm: () => {
-        if (!validate.isSubmitted && !validate.validateBeforeSubmitting)
-          return
-        validate.revalidateField('#accessibleAutocomplete')
-      }
-    });
+        if (!validate.isSubmitted && !validate.validateBeforeSubmitting) return
+        validate.revalidateField('#autocomplete')
+      },
+    })
     validate
-      .addField('#nome', [
+      .addField('#campoTesto', [
         {
           rule: 'required',
           errorMessage: 'Questo campo è richiesto',
         },
       ])
-      .addField('#accessibleAutocomplete', [
+      .addField('#autocomplete', [
         {
           rule: 'required',
           errorMessage: 'Questo campo è richiesto',
         },
         {
           validator: (value) => {
-            return comuni.includes(value);
+            return comuni.includes(value)
           },
           errorMessage: 'Scegli una città valida',
+        },
+      ])
+      .addField('#textarea', [
+        {
+          rule: 'required',
+          errorMessage: 'Questo campo è richiesto',
         },
       ])
       .addField('#importo_input_group', [
@@ -338,9 +398,9 @@ title: Validazione Form
         },
         {
           rule: 'minNumber',
-          value: 3.50,
-          errorMessage: 'Deve essere maggiore di 3.50',
-        }
+          value: 4,
+          errorMessage: 'Deve essere maggiore di 4',
+        },
       ])
       .addField('#perc_input_group', [
         {
@@ -349,11 +409,11 @@ title: Validazione Form
         },
         {
           rule: 'minNumber',
-          value: 80,
-          errorMessage: 'Deve essere maggiore di 80',
-        }
+          value: 90,
+          errorMessage: 'Deve essere maggiore di 90',
+        },
       ])
-      .addField('#etichetta_input_group', [
+      .addField('#etichetta_input_group_1', [
         {
           rule: 'required',
           errorMessage: 'Questo campo è richiesto',
@@ -362,7 +422,7 @@ title: Validazione Form
           rule: 'minNumber',
           value: 80,
           errorMessage: 'Deve essere maggiore di 80',
-        }
+        },
       ])
       .addField('#age', [
         {
@@ -415,6 +475,8 @@ title: Validazione Form
 
       .addRequiredGroup('#radiogroup', 'Scegli un’opzione')
       .addRequiredGroup('#checkgroup', 'Scegli almeno un’opzione')
+      .addRequiredGroup('#radiogroup-vertical', 'Scegli un’opzione')
+      .addRequiredGroup('#checkboxgroup-vertical', 'Scegli almeno un’opzione')
       .addField('#date', [
         {
           rule: 'required',

--- a/docs/form/autocompletamento.md
+++ b/docs/form/autocompletamento.md
@@ -14,6 +14,7 @@ Per la creazione del componente, è stato utilizzato il plugin [Accessible autoc
 
 {% comment %}Example name: Base{% endcomment %}
 {% capture example %}
+
 <div class="form-group">
   <label for="accessibleAutocomplete">Regione</label>
   <div id="accessibleAutocompleteWrapper" class="autocomplete-wrapper"></div>
@@ -33,15 +34,16 @@ Per la creazione del componente, è stato utilizzato il plugin [Accessible autoc
 
 ## Cambiare i valori dinamicamente
 
-In questo esempio viene mostrato come popolare il componente con dati che 
+In questo esempio viene mostrato come popolare il componente con dati che
 cambiano a fronte di un altro input, ad esempio il valore di un altro elemento
-di un form (come una select nell'esempio che segue). 
-Per far fronte a questa esigenza è sufficiente passare come opzione `source` 
+di un form (come una select nell'esempio che segue).
+Per far fronte a questa esigenza è sufficiente passare come opzione `source`
 una funzione per filtrare i dati e popolare il componente
 ([Tutte le opzioni disponibili del componente](#attivazione-tramite-codice)).
 
 {% comment %}Example name: Cambiare i valori dinamicamente{% endcomment %}
 {% capture example %}
+
 <div class="row">
   <div class="col-12">
     <div class="form-group">
@@ -102,6 +104,7 @@ una funzione per filtrare i dati e popolare il componente
 
 {% comment %}Example name: Regioni e Comuni{% endcomment %}
 {% capture example %}
+
 <div class="row">
   <div class="col-12">
     <div class="form-group">
@@ -152,16 +155,15 @@ una funzione per filtrare i dati e popolare il componente
 ## Validazione
 
 {% capture callout %}
-Per la validazione del campo con autocompletamento, si consiglia di utilizzare 
-il plugin Just Validate come da [guida]({{ site.baseurl }}/docs/form/introduzione/#validazione). 
-È possibile testare la validazione del campo con autocompletamento sulla 
+Per la validazione del campo con autocompletamento, si consiglia di utilizzare
+il plugin Just Validate come da [guida]({{ site.baseurl }}/docs/form/introduzione/#validazione).
+È possibile testare la validazione del campo con autocompletamento sulla
 [pagina di esempio validazione]({{ site.baseurl }}/docs/esempi/form/).
 {% endcapture %}{% include callout.html content=callout type="warning" %}
 
-
 Quando l'utente seleziona un valore dalla tendinda di Autocomplete occorre
 richiamare nuovamente la funzione di validazione. Questa chiamata può essere
-effettuata all'interno del metodo `onConfirm` che viene passato in configurazione 
+effettuata all'interno del metodo `onConfirm` che viene passato in configurazione
 e verrà chiamata ogni volta che l'utente seleziona un opzione.
 
 Ad esempio con JustValidate occorrerà istanziare il componente in questo modo
@@ -172,8 +174,8 @@ const selectAutocomplete = new SelectAutocomplete(selectAutocompleteWrapper, {
   id: 'idAutocomplete',
   onConfirm: () => {
     validate.revalidateField('#idAutocomplete')
-  }
-});
+  },
+})
 ```
 
 Il campo verrà validato così anche nel caso in cui l'utente seleziona un'opzione.
@@ -181,20 +183,20 @@ Nel caso in cui è stato impostato che JustValidate validi il form solo dopo la
 submit occorre controllare il suo stato
 
 ```js
-  onConfirm: () => {
-    if (!validate.isSubmitted && !validate.validateBeforeSubmitting)
-      return
-    validate.revalidateField('#idAutocomplete')
-  }
+onConfirm: () => {
+  if (!validate.isSubmitted && !validate.validateBeforeSubmitting) return
+  validate.revalidateField('#idAutocomplete')
+}
 ```
 
-Nell'esempio seguente si può provare questo comportamento (si noti che tra le 
-configurazioni è stato passato anche `minLength: 3`, vista la grande mole di dati 
-questa opzione impedirà la visualizzazione dei suggerimenti se vengono digitati 
+Nell'esempio seguente si può provare questo comportamento (si noti che tra le
+configurazioni è stato passato anche `minLength: 3`, vista la grande mole di dati
+questa opzione impedirà la visualizzazione dei suggerimenti se vengono digitati
 meno di 3 caratteri)
 
 {% comment %}Example name: Validazione{% endcomment %}
 {% capture example %}
+
 <div>
   <form id="justValidate">
     <div class="row">
@@ -213,10 +215,7 @@ meno di 3 caratteri)
   </form>
   <script>
     document.addEventListener('DOMContentLoaded', async function () {
-      const validate = new bootstrap.FormValidate('#justValidate', {
-        errorFieldCssClass: 'is-invalid',
-        errorLabelCssClass: 'form-feedback',
-        errorLabelStyle: '',
+      const validate = new bootstrap.FormValidate('#justValidate', {                     
         focusInvalidField: false,
       })
       const comuniJson = await (await fetch('{{ site.baseurl }}/docs/esempi/form/comuni.json')).json();
@@ -260,26 +259,26 @@ meno di 3 caratteri)
 È possibile abilitare l'autocomplete manualmente utilizzando l'oggetto `SelectAutocomplete`.
 
 ```js
-import { SelectAutocomplete } from 'bootstrap-italia';
+import { SelectAutocomplete } from 'bootstrap-italia'
 
-const autocompleteWrapperElement = document.querySelector('#wrapper-autocomplete');
-const autocomplete = new SelectAutocomplete(autocompleteWrapperElement, options);
+const autocompleteWrapperElement = document.querySelector('#wrapper-autocomplete')
+const autocomplete = new SelectAutocomplete(autocompleteWrapperElement, options)
 ```
 
 #### Opzioni
 
 ```js
-import { SelectAutocomplete } from 'bootstrap-italia';
+import { SelectAutocomplete } from 'bootstrap-italia'
 
-const selectAutocompleteWrapper = document.querySelector('#accessibleAutocompleteWrapper');
+const selectAutocompleteWrapper = document.querySelector('#accessibleAutocompleteWrapper')
 const selectAutocomplete = new SelectAutocomplete(selectAutocompleteWrapper, {
   source: ['Option 1', 'Option 2', 'Option 3'],
   id: 'accessibleAutocomplete',
   minLength: 3,
   onConfirm: (selectedElement) => {
-    console.log(selectedElement);
-  }
-});
+    console.log(selectedElement)
+  },
+})
 ```
 
 <div class="table-responsive">

--- a/docs/form/introduzione.md
+++ b/docs/form/introduzione.md
@@ -27,12 +27,15 @@ Strutture più complesse possono essere costruite usando il sistema a griglia, d
 Si può scegliere di dare una dimensione ad una colonna, ad esempio dandogli una classe `.col-md-6` per ottenere una certo design dal breakpoint `md` in su, mentre le restanti `.col-md` si divideranno il resto dello spazio.
 
 {% capture callout %}
+
 #### Separare le colonne dai campi
+
 Non utilizzare la classe di tipo `.col-*` sullo stesso elemento che contiene un campo del form, altrimenti la spaziatura di quest'ultimo verrà reimpostata in modo errato. **Separa sempre il layout dal contenuto**.
 {% endcapture %}{% include callout.html content=callout type="warning" %}
 
 {% comment %}Example name: Dimensionamento colonne{% endcomment %}
 {% capture example %}
+
 <div>
   <div class="row">
     <div class="col-md-6">
@@ -75,6 +78,7 @@ Ecco l'esempio di una struttura più complessa creata con il sistema a griglie.
 
 {% comment %}Example name: Con sistema a griglie{% endcomment %}
 {% capture example %}
+
 <div>
   <div class="row">
     <div class="col-md-6">
@@ -162,6 +166,7 @@ L'esempio seguente usa una delle [utilità di flexbox]({{ site.baseurl }}/docs/o
 
 {% comment %}Example name: Auto-dimensionamento {% endcomment %}
 {% capture example %}
+
 <div class="row align-items-center">
   <div class="col-12 col-md-6 col-lg-auto">
     <label class="visually-hidden" for="inlineFormInput">Nome</label>
@@ -211,6 +216,7 @@ Aggiungi l'attributo `disabled` al `<fieldset>` per disabilitare tutti gli eleme
 
 {% comment %}Example name: Form disabilitato {% endcomment %}
 {% capture example %}
+
 <div>
   <fieldset disabled aria-label="Form disabilitato">
     <legend class="mb-4">Esempio di form disabilitato</legend>
@@ -288,12 +294,13 @@ Per il funzionamento e le opzioni disponibili, si consiglia di consultare la [do
 
 ### Stili personalizzati
 
-I campi che necessitano di validazione acquisiranno all'invio del form le classi CSS definite nello script che attiva il plugin. Nel nostro caso le classi saranno `is-invalid` e `just-validate-success-field`. I messaggi di errore avranno classe `just-validate-error-label`.
+I campi che necessitano di validazione acquisiranno all'invio del form le classi CSS definite nello script che attiva il plugin. Nel nostro caso le classi saranno `is-invalid` e `is-valid`. I messaggi di errore avranno classe `form-feedback.text-danger`.
 
 Di seguito un esempio di form validato con Just Validate.
 
 {% comment %}Example name: Con validazione {% endcomment %}
 {% capture example %}
+
 <form class="needs-validation" id="justValidateForm">
   <div class="row mt-4">
     <div class="form-group col-md-3">
@@ -348,10 +355,7 @@ Di seguito un esempio di form validato con Just Validate.
   document.addEventListener("DOMContentLoaded", function() {
     const errorMessage = '<div class="alert alert-danger alert-dismissible fade show" role="alert"><strong>Attenzione</strong> Alcuni campi inseriti sono da controllare.<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Chiudi avviso">';
     const errorWrapper = document.querySelector('#errorMsgContainer');
-    const validate = new bootstrap.FormValidate('#justValidateForm', {
-      errorFieldCssClass: 'is-invalid',
-      errorLabelCssClass: 'form-feedback',
-      errorLabelStyle: '',
+    const validate = new bootstrap.FormValidate('#justValidateForm', {         
       focusInvalidField: false,
     })
     validate

--- a/docs/form/introduzione.md
+++ b/docs/form/introduzione.md
@@ -294,7 +294,9 @@ Per il funzionamento e le opzioni disponibili, si consiglia di consultare la [do
 
 ### Stili personalizzati
 
-I campi che necessitano di validazione acquisiranno all'invio del form le classi CSS definite nello script che attiva il plugin. Nel nostro caso le classi saranno `is-invalid` e `is-valid`. I messaggi di errore avranno classe `form-feedback.text-danger`.
+I campi che necessitano di validazione acquisiranno all'invio del form le classi CSS definite nello script che attiva il plugin. Nel nostro caso le classi saranno `is-invalid` e `is-valid`.
+
+I messaggi di errore avranno classe `form-feedback text-danger`, mentre eventuali messaggi di successo avranno classe `form-feedback text-success`.
 
 Di seguito un esempio di form validato con Just Validate.
 
@@ -443,3 +445,15 @@ Di seguito un esempio di form validato con Just Validate.
 I singoli campi di tipo _input_, _checkbox_, _radio_, _toggle_, ecc. sono trattati in pagine separate della documentazione, continua a leggere alla pagina dedicata ai [campi di input]({{ site.baseurl }}/docs/form/input/).
 
 {% include properties.md properties=site.data.cprops.form %}
+
+## Breaking change
+
+{% capture callout %}
+La validazione con JustValidate, e le classi che applicano gli stili di validazione, non sono più dipendenti dal plugin JustValidate. Migliorato il comportamento di default di JustValidate.
+
+- La classe `just-validate-success-field` è stata sostiuita con la classe `is-valid`.
+- La classe `just-validate-error-label` è stata sostituita dalle classi `form-feedback text-danger`.
+- La classe `just-validate-success-label` è stata sostituita dalle classi `form-feedback text-success`.
+- Di default, il plugin di JustValidate integrato in BootstrapItalia imposta `focusInvalidField` a `false` per evitare lo scroll del form al primo campo con errore.
+
+{% endcapture %}{% include callout-breaking.html content=callout version="3.0.0" type="danger" %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2627,9 +2627,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2651,9 +2648,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2675,9 +2669,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2699,9 +2690,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2723,9 +2711,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2747,9 +2732,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3082,9 +3064,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3099,9 +3078,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3116,9 +3092,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3133,9 +3106,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3150,9 +3120,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3167,9 +3134,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3184,9 +3148,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3201,9 +3162,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3218,9 +3176,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3235,9 +3190,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3252,9 +3204,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3269,9 +3218,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3286,9 +3232,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -105,5 +105,6 @@
     "progressbar.js": "^1.1.0",
     "uuid": "^14.0.0",
     "video.js": "^8.23.7"
-  }
+  },
+  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531"
 }

--- a/src/js/plugins/form-validate.js
+++ b/src/js/plugins/form-validate.js
@@ -10,8 +10,14 @@ import JustValidate from 'just-validate'
 import { CssClassObserver, ContentObserver } from './util/observer'
 
 const CONFIG_DEFAULT = {
-  errorFieldCssClass: 'is-invalid',
-  errorLabelCssClass: 'just-validate-error-label',
+  focusInvalidField: false, //if true, the first invalid field will be focused after the form submitting.
+  errorLabelCssClass: 'form-feedback text-danger', //default: just-validate-error-label
+  successLabelCssClass: 'form-feedback text-success', //default: just-validate-success-label
+  errorFieldCssClass: 'is-invalid', //default: just-validate-error-field
+  successFieldCssClass: 'is-valid', //default: just-validate-success-field
+
+  errorFieldStyle: '',
+  errorLabelStyle: '', //default: {color: '#b81111'}
 }
 
 const NAME = 'justvalidatebi'
@@ -30,15 +36,20 @@ class FormValidate {
 
     if (dictLocale != undefined) this.validate = new JustValidate(selector, config, dictLocale)
     else {
-      this.validate = new JustValidate(selector, config)
+      this.validate = new JustValidate(selector, Object.assign({}, CONFIG_DEFAULT, config))
     }
 
-    this.config = Object.assign({}, CONFIG_DEFAULT, this.validate.globalConfig)
+    this.config = Object.assign({}, this.validate.globalConfig)
+    console.log('config', { 'this.config': this.config, CONFIG_DEFAULT, 'this.validate.globalConfig': this.validate.globalConfig })
     this.formItems = []
 
     this.init()
 
     return this.validate
+  }
+
+  getCssSelectorFromClass(cl) {
+    return '.' + cl.replaceAll(' ', '.')
   }
 
   init() {
@@ -65,7 +76,7 @@ class FormValidate {
       if (inputs.length > 0) {
         const watcher = new ContentObserver(
           field,
-          '.' + this.config.errorLabelCssClass,
+          this.getCssSelectorFromClass(this.config.errorLabelCssClass),
           () => this.onFieldsetError(field),
           () => this.onFieldsetErrorRemove(field)
         )
@@ -153,10 +164,11 @@ class FormValidate {
    */
   getErrorMessages(target) {
     let parent = target
-    let messages = parent.querySelectorAll('.' + this.config.errorLabelCssClass)
+    const errorLabelSelector = this.getCssSelectorFromClass(this.config.errorLabelCssClass)
+    let messages = parent.querySelectorAll(errorLabelSelector)
     while (parent != null && messages.length === 0) {
       parent = parent.parentNode
-      messages = parent.querySelectorAll('.' + this.config.errorLabelCssClass)
+      messages = parent.querySelectorAll(errorLabelSelector)
     }
     return messages
   }

--- a/src/scss/bootstrap-italia.scss
+++ b/src/scss/bootstrap-italia.scss
@@ -141,5 +141,6 @@
 @forward 'forms/form-transfer';
 @forward 'forms/accessible-autocomplete';
 @forward 'forms/autocomplete';
-@forward 'forms/just-validate';
+//@forward 'forms/just-validate';
+@forward 'forms/form-validation';
 // ------------------------------

--- a/src/scss/forms/_form-control.scss
+++ b/src/scss/forms/_form-control.scss
@@ -36,34 +36,13 @@
 .form-control {
   background-repeat: no-repeat;
   background-position: center right;
-  background-size: 45px 30%;
+  background-size: 45px 20px;
 
   &:disabled {
     cursor: not-allowed;
     background: var(--#{$prefix}color-background-disabled);
     border: 0;
     color: var(--#{$prefix}color-text-disabled);
-  }
-
-  .was-validated &:valid,
-  &.is-valid {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23008055' viewBox='0 0 192 512'%3E%3Cpath d='M435.848 83.466L172.804 346.51l-96.652-96.652c-4.686-4.686-12.284-4.686-16.971 0l-28.284 28.284c-4.686 4.686-4.686 12.284 0 16.971l133.421 133.421c4.686 4.686 12.284 4.686 16.971 0l299.813-299.813c4.686-4.686 4.686-12.284 0-16.971l-28.284-28.284c-4.686-4.686-12.284-4.686-16.97 0z'/%3E%3C/svg%3E");
-  }
-
-  .was-validated &:invalid,
-  &.is-invalid {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23cc334d' viewBox='0 0 384 512'%3E%3Cpath d='M231.6 256l130.1-130.1c4.7-4.7 4.7-12.3 0-17l-22.6-22.6c-4.7-4.7-12.3-4.7-17 0L192 216.4 61.9 86.3c-4.7-4.7-12.3-4.7-17 0l-22.6 22.6c-4.7 4.7-4.7 12.3 0 17L152.4 256 22.3 386.1c-4.7 4.7-4.7 12.3 0 17l22.6 22.6c4.7 4.7 12.3 4.7 17 0L192 295.6l130.1 130.1c4.7 4.7 12.3 4.7 17 0l22.6-22.6c4.7-4.7 4.7-12.3 0-17L231.6 256z'/%3E%3C/svg%3E");
-    border-color: var(--#{$prefix}color-border-danger);
-  }
-
-  &.warning {
-    background-image: url('data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%0A%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M2%2012C2%206.47715%206.47715%202%2012%202C14.6522%202%2017.1957%203.05357%2019.0711%204.92893C20.9464%206.8043%2022%209.34784%2022%2012C22%2017.5228%2017.5228%2022%2012%2022C6.47715%2022%202%2017.5228%202%2012ZM3%2012C3%2016.9706%207.02944%2021%2012%2021C16.9706%2021%2021%2016.9706%2021%2012C21%207.02944%2016.9706%203%2012%203C7.02944%203%203%207.02944%203%2012ZM11.5%2014.2V5.7H12.7V14.2H11.5ZM12.6%2018.3V16.5H11.4V18.3H12.6Z%22/%3E%0A%3C/svg%3E')
-      no-repeat;
-    border-color: var(--#{$prefix}color-border-warning);
-  }
-
-  &.is-valid ~ .warning-feedback {
-    display: block;
   }
 }
 

--- a/src/scss/forms/_form-validation.scss
+++ b/src/scss/forms/_form-validation.scss
@@ -88,12 +88,3 @@ textarea {
     background-position: top 0.5em right !important;
   }
 }
-
-// input[type='checkbox'],
-// input[type='radio'] {
-//   &.is-invalid {
-//     ~ label {
-//       --#{$prefix}form-checkbox-border-color: var(--#{$prefix}color-border-danger);
-//     }
-//   }
-// }

--- a/src/scss/forms/_form-validation.scss
+++ b/src/scss/forms/_form-validation.scss
@@ -37,9 +37,27 @@ button:has(~ .is-invalid),
   }
 }
 
+.was-validated &:valid,
 .is-valid {
   border-color: var(--#{$prefix}color-border-success) !important;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23008055' viewBox='0 0 192 512'%3E%3Cpath d='M435.848 83.466L172.804 346.51l-96.652-96.652c-4.686-4.686-12.284-4.686-16.971 0l-28.284 28.284c-4.686 4.686-4.686 12.284 0 16.971l133.421 133.421c4.686 4.686 12.284 4.686 16.971 0l299.813-299.813c4.686-4.686 4.686-12.284 0-16.971l-28.284-28.284c-4.686-4.686-12.284-4.686-16.97 0z'/%3E%3C/svg%3E");
+  background-image: url('data:image/svg+xml,<svg width="24" height="24" viewBox="0 0 24 24" fill="%23008055" xmlns="http://www.w3.org/2000/svg"><path d="M9.6,16.9L4,11.4l0.8-0.7l4.8,4.8l8.5-8.4l0.7,0.7L9.6,16.9z" /></svg>');
+
+  ~ .warning-feedback {
+    display: block;
+  }
+}
+
+.was-validated &:invalid,
+.is-invalid {
+  border-color: var(--#{$prefix}color-border-danger) !important;
+  background-image: url('data:image/svg+xml,<svg width="24" fill="%23cc334d" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12.7,12l6.7,6.6l-0.8,0.8L12,12.7l-6.6,6.7l-0.8-0.8l6.7-6.6L4.6,5.4l0.8-0.8l6.6,6.7l6.6-6.7l0.8,0.8L12.7,12z" /></svg>');
+}
+
+.form-control {
+  &.warning {
+    border-color: var(--#{$prefix}color-border-warning) !important;
+    background-image: url('data:image/svg+xml,<svg width="24" height="24" fill="%23995c00" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12.5,17h-1V2h1V17z M12.5,20h-1v2h1V20z" /></svg>');
+  }
 }
 
 .input-group-text:has(~ .is-valid),
@@ -67,31 +85,15 @@ button:has(~ .is-valid),
 
 textarea {
   &.form-control {
-    background-position: top 0.3em right 0.3em !important;
-    background-size: 37px 30% !important;
-  }
-  &.is-invalid {
-    border-bottom-style: solid;
-    border-bottom-width: 1px;
-  }
-  &.is-valid {
-    border-bottom-style: solid;
-    border-bottom-width: 1px;
+    background-position: top 0.5em right !important;
   }
 }
 
-input[type='checkbox'],
-input[type='radio'] {
-  &.is-invalid {
-    --#{$prefix}form-checkbox-border-color: var(--#{$prefix}color-border-danger);
-  }
-}
-
-select {
-  &.is-invalid {
-    border: 1px solid var(--#{$prefix}color-border-danger);
-  }
-  &.is-valid {
-    border: 1px solid var(--#{$prefix}color-border-success);
-  }
-}
+// input[type='checkbox'],
+// input[type='radio'] {
+//   &.is-invalid {
+//     ~ label {
+//       --#{$prefix}form-checkbox-border-color: var(--#{$prefix}color-border-danger);
+//     }
+//   }
+// }

--- a/src/scss/forms/_form-validation.scss
+++ b/src/scss/forms/_form-validation.scss
@@ -5,10 +5,6 @@
   width: 100%;
   margin-top: 0.25rem;
   font-size: 0.75rem;
-
-  &.just-validate-error-label {
-    color: var(--#{$prefix}color-text-danger);
-  }
 }
 
 .input-group-text:has(~ [data-focus-mouse='true']:not(.btn)),
@@ -32,21 +28,29 @@ button:has(~ .is-invalid),
   display: none;
 }
 
-.just-validate-success-field {
-  border-color: var(--#{$prefix}color-border-success) !important;
+.is-valid,
+.is-invalid {
   padding-right: calc(1.5em + 0.75rem) !important;
+
+  &[type='number'] {
+    padding-right: calc(1.5em + 0.75rem + var(--#{$prefix}form-control-spacing) + 1rem) !important;
+  }
+}
+
+.is-valid {
+  border-color: var(--#{$prefix}color-border-success) !important;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23008055' viewBox='0 0 192 512'%3E%3Cpath d='M435.848 83.466L172.804 346.51l-96.652-96.652c-4.686-4.686-12.284-4.686-16.971 0l-28.284 28.284c-4.686 4.686-4.686 12.284 0 16.971l133.421 133.421c4.686 4.686 12.284 4.686 16.971 0l299.813-299.813c4.686-4.686 4.686-12.284 0-16.971l-28.284-28.284c-4.686-4.686-12.284-4.686-16.97 0z'/%3E%3C/svg%3E");
 }
 
-.input-group-text:has(~ .just-validate-success-field),
-.just-validate-success-field ~ .input-group-text,
-button:has(~ .just-validate-success-field),
-.just-validate-success-field + button {
+.input-group-text:has(~ .is-valid),
+.is-valid ~ .input-group-text,
+button:has(~ .is-valid),
+.is-valid + button {
   border-color: var(--#{$prefix}color-border-success);
 }
 
 //move buttons to make validation icon visible
-.just-validate-success-field + .input-group-text.align-buttons,
+.is-valid + .input-group-text.align-buttons,
 .is-invalid + .input-group-text.align-buttons {
   right: 30px;
 }
@@ -56,7 +60,7 @@ button:has(~ .just-validate-success-field),
 }
 
 .autocomplete__wrapper {
-  .form-feedback.just-validate-error-label {
+  .form-feedback {
     position: absolute;
   }
 }
@@ -70,7 +74,7 @@ textarea {
     border-bottom-style: solid;
     border-bottom-width: 1px;
   }
-  &.just-validate-success-field {
+  &.is-valid {
     border-bottom-style: solid;
     border-bottom-width: 1px;
   }
@@ -87,7 +91,7 @@ select {
   &.is-invalid {
     border: 1px solid var(--#{$prefix}color-border-danger);
   }
-  &.just-validate-success-field {
+  &.is-valid {
     border: 1px solid var(--#{$prefix}color-border-success);
   }
 }

--- a/src/scss/forms/_forms.scss
+++ b/src/scss/forms/_forms.scss
@@ -452,7 +452,7 @@ input::-webkit-datetime-edit {
       }
     }
 
-        // Hover state
+    // Hover state
     + label:hover::before {
       border-color: var(--#{$prefix}color-border-secondary-hover);
     }
@@ -481,8 +481,6 @@ input::-webkit-datetime-edit {
         }
       }
     }
-
-
   }
 
   .form-text {


### PR DESCRIPTION
## Descrizione

Uniformate le cassi e gli stili di validazione per renderli indipendenti dal plugin JustValidate.
Fixes #1511 

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
