### PR TITLE
fix(modal, main): responsive scrollable modal at high zoom and inert background isolation

### DIFF
--- a/src/js/plugins/modal.js
+++ b/src/js/plugins/modal.js
@@ -61,6 +61,29 @@ const DefaultType = {
   keyboard: 'boolean',
 }
 
+// Elements outside the modal must be isolated from assistive technology (e.g. VoiceOver's
+// virtual cursor) while the modal is open, since the focus trap alone doesn't stop that kind
+// of navigation. `inert` is reference-counted because two modal instances can end up inerting
+// the same background elements at once (see the data-api handler swapping an open modal for
+// another one), so the first one to close must not remove `inert` while the second still needs it.
+const inertCounts = new Map()
+const setInert = (el) => {
+  const count = inertCounts.get(el) || 0
+  if (count === 0) {
+    el.setAttribute('inert', '')
+  }
+  inertCounts.set(el, count + 1)
+}
+const unsetInert = (el) => {
+  const count = inertCounts.get(el) || 0
+  if (count <= 1) {
+    inertCounts.delete(el)
+    el.removeAttribute('inert')
+  } else {
+    inertCounts.set(el, count - 1)
+  }
+}
+
 /**
  * Class definition
  */
@@ -75,6 +98,7 @@ class Modal extends BaseComponent {
     this._isShown = false
     this._isTransitioning = false
     this._scrollBar = new ScrollBarHelper()
+    this._inertedElements = []
 
     this._addEventListeners()
   }
@@ -149,6 +173,7 @@ class Modal extends BaseComponent {
 
     this._backdrop.dispose()
     this._focustrap.deactivate()
+    this._removeInert()
     super.dispose()
   }
 
@@ -175,6 +200,9 @@ class Modal extends BaseComponent {
     if (!document.body.contains(this._element)) {
       document.body.append(this._element)
     }
+
+    // the modal may have just been (re)parented above, so (re)compute the ancestor chain now
+    this._applyInert()
 
     this._element.style.display = 'block'
     this._element.removeAttribute('aria-hidden')
@@ -256,6 +284,9 @@ class Modal extends BaseComponent {
       document.body.classList.remove(CLASS_NAME_OPEN)
       this._resetAdjustments()
       this._scrollBar.reset()
+      // background must not be inert anymore before EVENT_HIDDEN fires, since focus is
+      // restored to the trigger element (which may be one of the previously inerted elements)
+      this._removeInert()
       EventHandler.trigger(this._element, EVENT_HIDDEN)
     })
   }
@@ -315,6 +346,43 @@ class Modal extends BaseComponent {
   _resetAdjustments() {
     this._element.style.paddingLeft = ''
     this._element.style.paddingRight = ''
+  }
+
+  _applyInert() {
+    this._inertedElements = []
+
+    let current = this._element
+    while (current && current !== document.body && current.parentElement) {
+      const parent = current.parentElement
+      for (const sibling of parent.children) {
+        if (sibling === current || !(sibling instanceof HTMLElement)) {
+          continue
+        }
+
+        if (['SCRIPT', 'STYLE', 'TEMPLATE', 'LINK'].includes(sibling.tagName)) {
+          continue
+        }
+
+        // other modals/backdrops are already display:none + aria-hidden; inert-ing them here
+        // would create a race when one modal replaces another (see data-api handler below)
+        if (sibling.matches('.modal, .modal-backdrop')) {
+          continue
+        }
+
+        setInert(sibling)
+        this._inertedElements.push(sibling)
+      }
+
+      current = parent
+    }
+  }
+
+  _removeInert() {
+    for (const element of this._inertedElements) {
+      unsetInert(element)
+    }
+
+    this._inertedElements = []
   }
 }
 

--- a/src/js/plugins/modal.js
+++ b/src/js/plugins/modal.js
@@ -84,6 +84,55 @@ const unsetInert = (el) => {
   }
 }
 
+// `ScrollBarHelper` sets `overflow: hidden` on `document.body` to lock the background while a
+// modal is open, but per spec an `overflow: hidden` box is only blocked from *user-driven*
+// scrolling (wheel/trackpad/keyboard); it remains programmatically scrollable. VoiceOver on
+// macOS Safari moves its virtual cursor with a "scroll the a11y focus target into view" step
+// that is exactly such a programmatic scroll, and WebKit acts on it by scrolling the window even
+// though the modal itself is visually isolated in a `position: fixed` dialog -- Chromium doesn't.
+// The result is the background page sliding around behind the modal, and possibly ending up at a
+// different scroll position on close (#1705). Taking `document.body` out of the scrollable flow
+// entirely (`position: fixed`) removes any scrollable overflow for WebKit's accessibility code to
+// act on, which the plain `overflow: hidden` above cannot do.
+//
+// This is scoped to modal.js only (offcanvas/navbar-collapsible keep using `ScrollBarHelper`
+// as-is) and is reference-counted like `inert` above, for the same reason: the data-api handler
+// below can swap an already-open modal for another one, and the first modal's deferred
+// `_hideModal` (it runs after the backdrop transition, i.e. potentially after the next modal's
+// `show()` already ran) must not release the lock -- or restore the saved scroll position --
+// while the next modal is still relying on it. Because the saved position is only (re)captured
+// when the count goes from 0 to 1, a second modal taking over an already-locked body never saves
+// the bogus `window.scrollY === 0` that `position: fixed` body would otherwise report.
+let scrollLockCount = 0
+let savedScrollY = 0
+const lockBackgroundScroll = () => {
+  if (scrollLockCount === 0) {
+    savedScrollY = window.scrollY || window.pageYOffset || 0
+    const { style } = document.body
+    style.position = 'fixed'
+    style.top = `${-savedScrollY}px`
+    style.left = '0'
+    style.right = '0'
+    style.width = '100%'
+  }
+
+  scrollLockCount++
+}
+const unlockBackgroundScroll = () => {
+  scrollLockCount = Math.max(0, scrollLockCount - 1)
+  if (scrollLockCount > 0) {
+    return
+  }
+
+  const { style } = document.body
+  style.removeProperty('position')
+  style.removeProperty('top')
+  style.removeProperty('left')
+  style.removeProperty('right')
+  style.removeProperty('width')
+  window.scrollTo(0, savedScrollY)
+}
+
 /**
  * Class definition
  */
@@ -99,6 +148,7 @@ class Modal extends BaseComponent {
     this._isTransitioning = false
     this._scrollBar = new ScrollBarHelper()
     this._inertedElements = []
+    this._scrollLocked = false
 
     this._addEventListeners()
   }
@@ -138,6 +188,8 @@ class Modal extends BaseComponent {
     this._isTransitioning = true
 
     this._scrollBar.hide()
+    this._scrollLocked = true
+    lockBackgroundScroll()
 
     document.body.classList.add(CLASS_NAME_OPEN)
 
@@ -174,6 +226,11 @@ class Modal extends BaseComponent {
     this._backdrop.dispose()
     this._focustrap.deactivate()
     this._removeInert()
+    if (this._scrollLocked) {
+      this._scrollLocked = false
+      unlockBackgroundScroll()
+    }
+
     super.dispose()
   }
 
@@ -284,6 +341,11 @@ class Modal extends BaseComponent {
       document.body.classList.remove(CLASS_NAME_OPEN)
       this._resetAdjustments()
       this._scrollBar.reset()
+      if (this._scrollLocked) {
+        this._scrollLocked = false
+        unlockBackgroundScroll()
+      }
+
       // background must not be inert anymore before EVENT_HIDDEN fires, since focus is
       // restored to the trigger element (which may be one of the previously inerted elements)
       this._removeInert()

--- a/src/scss/components/_modal.scss
+++ b/src/scss/components/_modal.scss
@@ -299,13 +299,25 @@
     }
   }
   // scrollable variation
+  //
+  // The available height is derived from `.modal-dialog`'s own margin (via its own copy of
+  // `--#{$prefix}modal-margin`, kept separate from `.modal`'s so regular, non-scrollable modals
+  // are unaffected) instead of hardcoded viewport offsets. `.modal` is `position: fixed; height: 100%`,
+  // so `100%` here already resolves against the viewport and, unlike `100vh`, isn't inflated by
+  // mobile browser UI chrome. Capped with `10vh` so a wide-but-short viewport (e.g. landscape
+  // phones, or a small effective viewport from a high browser zoom level) doesn't lose a fixed
+  // amount of height to top/bottom margins.
   &.it-dialog-scrollable {
     .modal-dialog {
-      margin: $v-gap * 13 $modal-margin;
+      --#{$prefix}modal-margin: #{min($v-gap * 13, 10vh)};
+      height: calc(100% - var(--#{$prefix}modal-margin) * 2);
+      margin: var(--#{$prefix}modal-margin) $modal-margin;
       .modal-content {
         display: flex;
         flex-direction: column;
-        height: calc(100vh - #{$v-gap * 26});
+        height: 100%;
+        max-height: 100%;
+        overflow: hidden;
         .modal-header {
           padding-bottom: $modal-padding;
           background: $modal-sticky-bg;
@@ -322,18 +334,18 @@
         }
       }
       &.modal-dialog-left {
-        height: 100vh;
+        height: 100%;
         margin: 0 $v-gap * 3 0 0;
         .modal-content {
-          height: 100vh;
+          height: 100%;
         }
       }
       &.modal-dialog-right {
-        height: 100vh;
+        height: 100%;
         margin: 0 0 0 $v-gap * 3;
         float: right;
         .modal-content {
-          height: 100vh;
+          height: 100%;
         }
       }
     }
@@ -395,23 +407,27 @@
       &.modal-dialog-left {
         margin: 0;
         .modal-content {
-          height: 100vh;
+          height: 100%;
         }
       }
       &.modal-dialog-right {
         margin: 0;
         float: right;
         .modal-content {
-          height: 100vh;
+          height: 100%;
         }
       }
     }
+    // Vertical margin/height on `.modal-dialog` and height/max-height on `.modal-content` are
+    // already derived from `--#{$prefix}modal-margin` by the base rules above, so only the
+    // custom property needs overriding here. The horizontal margin isn't part of that token
+    // (it stays a fixed $modal-margin gutter below this breakpoint, see base rules), so it's
+    // restored to `auto` explicitly to keep the dialog centered at this and larger breakpoints.
     &.it-dialog-scrollable {
       .modal-dialog {
-        margin: $v-gap * 8 auto;
-        .modal-content {
-          height: calc(100vh - #{$v-gap * 16});
-        }
+        --#{$prefix}modal-margin: #{min($v-gap * 8, 10vh)};
+        margin-left: auto;
+        margin-right: auto;
       }
     }
   }


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Fixes #1705 per il branch main

Risolve i problemi di scorrimento indesiderato dello sfondo su Safari con VoiceOver e migliora il layout delle modali ad alto livello di zoom.

#### Modifiche principali
Blocco scroll sfondo: Usato position: fixed su document.body (al posto di overflow: hidden) in modal.js per impedire a WebKit/VoiceOver lo scroll programmatico.

Gestione stato (ref-counting): Blocco dello scroll e attributo inert regolati da conteggio dei riferimenti per gestire il passaggio rapido tra più modali.

Supporto alto zoom: Calcolo altezza di .it-dialog-scrollable via custom property per gestire zoom fino al 400% e schermi mobile orizzontali.

Fix CSS: Corretto calc() errato con margini auto su modali centrate e scorrevoli.

#### Ambito
Modifiche isolate a modal.js e relativi stili.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
