### PR TITLE
fix(input-search-autocomplete): sanitize option HTML and escape regex

### DIFF
--- a/src/js/plugins/input-search-autocomplete.js
+++ b/src/js/plugins/input-search-autocomplete.js
@@ -9,14 +9,28 @@
 import BaseComponent from './base-component'
 import EventHandler from './dom/event-handler'
 import InputLabel from './input-label'
+import { DefaultAllowlist, sanitizeHtml } from './util/sanitizer'
 
 const NAME = 'inputsearchautocomplete'
 const DATA_KEY = 'bs.inputsearchautocomplete'
 const EVENT_KEY = `.${DATA_KEY}`
 
+const AutocompleteAllowlist = {
+  ...DefaultAllowlist,
+  mark: [],
+  svg: ['xmlns', 'viewBox', 'fill', 'width', 'height', 'focusable', 'aria-hidden'],
+  use: ['href', 'xlink:href'],
+}
+
 const Default = {
   autocomplete: [],
+  allowList: AutocompleteAllowlist,
+  sanitize: true,
+  sanitizeFn: null,
 }
+
+const REGEXP_SPECIAL_CHARS = /[\\^$.*+?()[\]{}|]/g
+const escapeRegExp = (str) => String(str).replace(REGEXP_SPECIAL_CHARS, String.raw`\$&`)
 
 const EVENT_KEYUP = `keyup${EVENT_KEY}`
 
@@ -55,17 +69,20 @@ class InputSearch extends BaseComponent {
     this._autocompleteElement.innerHTML = ''
 
     if (value) {
+      const itemText = (item) => (typeof item.text === 'string' ? item.text : '')
+      const markText = new RegExp('(' + escapeRegExp(value) + ')', 'gi')
       this._items.forEach((item) => {
-        let markText = new RegExp('(' + value + ')', 'gi')
-        let optionText = item.text.replace(markText, '<mark>$1</mark>')
-        let optionLabel = item.label ? '<em>' + item.label + '</em>' : ''
-        let optionIcon = item.icon ? item.icon : ''
-        let optionLink = item.link ? item.link : '#'
-
-        if (optionText.toLowerCase().indexOf(value.toLowerCase()) !== -1) {
-          this._autocompleteElement.classList.add(CLASS_NAME_SHOW)
-          this._autocompleteElement.appendChild(this._createOption(optionLink, optionText, optionLabel, optionIcon))
+        const text = itemText(item)
+        if (!text.toLowerCase().includes(value.toLowerCase())) {
+          return
         }
+        const optionText = text.replace(markText, '<mark>$1</mark>')
+        const optionLabel = item.label ? '<em>' + item.label + '</em>' : ''
+        const optionIcon = item.icon ? item.icon : ''
+        const optionLink = item.link ? item.link : '#'
+
+        this._autocompleteElement.classList.add(CLASS_NAME_SHOW)
+        this._autocompleteElement.appendChild(this._createOption(optionLink, optionText, optionLabel, optionIcon))
       })
     } else {
       this._autocompleteElement.classList.remove(CLASS_NAME_SHOW)
@@ -111,13 +128,21 @@ class InputSearch extends BaseComponent {
       return
     }
     const option = document.createElement('li')
-    option.innerHTML = `<a href="${link}">
+    const rawHtml = `<a href="${link}">
         ${icon}
         <span class="autocomplete-list-text">
           <span>${text}</span>
           ${label}
         </span>
       </a>`
+    option.innerHTML = this._config.sanitize ? sanitizeHtml(rawHtml, this._config.allowList, this._config.sanitizeFn) : rawHtml
+
+    // If the sanitizer dropped the href (e.g. javascript: scheme),
+    // fall back to "#" so the option stays a proper anchor.
+    const anchor = option.querySelector('a')
+    if (anchor && !anchor.hasAttribute('href')) {
+      anchor.setAttribute('href', '#')
+    }
 
     return option
   }

--- a/types/plugins/input-search-autocomplete.d.ts
+++ b/types/plugins/input-search-autocomplete.d.ts
@@ -47,6 +47,25 @@ declare namespace InputSearch {
      * @default []
      */
     autocomplete: any[],
+    /**
+     * Allowed HTML tags and attributes for sanitization of option content.
+     * Defaults to the DefaultAllowlist extended with `mark`, `svg`, `use`.
+     */
+    allowList: Record<string, Array<string | RegExp>>,
+    /**
+     * Enable HTML sanitization of option content. Disable only if `autocomplete`
+     * is populated exclusively from trusted sources.
+     *
+     * @default true
+     */
+    sanitize: boolean,
+    /**
+     * Custom sanitization function. If provided, replaces the built-in sanitizer
+     * (e.g. pipe through DOMPurify).
+     *
+     * @default null
+     */
+    sanitizeFn: ((html: string) => string) | null,
   }
 
 }


### PR DESCRIPTION
## Descrizione

Hardening di `InputSearch` (`input-search`/autocomplete).

`_createOption()` costruiva l'HTML dell'opzione assegnando `option.innerHTML` con i campi del dataset (`link`, `text`, `label`, `icon`) interpolati come HTML grezzo, senza sanitizzazione né controllo sullo schema dell'URL. Inoltre il valore digitato nella search veniva passato direttamente al costruttore `RegExp`, quindi un carattere meta come `(` o `[` faceva sollevare un `SyntaxError` interrompendo la ricerca.

Cosa cambia:

- L'HTML generato passa per il `sanitizeHtml` già presente nel progetto (lo stesso usato da tooltip e popover). L'`<a href>` viene validato da `SAFE_URL_PATTERN`: sopravvivono `http(s)`, `mailto`, `ftp`, `tel`, `file`, `sms` e gli URL relativi.
- L'allowlist di default è estesa con `mark`, `svg` e `use`, così restano intatti l'evidenziazione del testo e il pattern documentato delle icone sprite (`<svg><use href="…#icona"></use></svg>`).
- Il valore di ricerca viene sottoposto a escape prima di costruire la `RegExp` di evidenziazione: digitare `(`, `[`, `\d+` ora è sicuro e produce un match letterale.
- La regex di evidenziazione viene costruita una volta per `search()` invece che una volta per elemento.
- Controllo di tipo su `item.text`, così un campo non stringa non interrompe il ciclo.
- Se il sanitizer rimuove un `href` non ammesso, si ricade su `href="#"`: l'ancora resta un no-op cliccabile invece di diventare un link rotto.
- `allowList`, `sanitize` e `sanitizeFn` diventano opzioni configurabili, allineate all'API di tooltip/popover. I default sono sicuri (`sanitize: true` più l'allowlist estesa); chi ha esigenze legittime particolari (schemi URL custom, `<path>` SVG inline, pipeline DOMPurify) ha una via d'uscita senza dover forkare.
- `types/plugins/input-search-autocomplete.d.ts` aggiornato con le tre nuove opzioni.

Nota: deriva dalla PR aperta nel fork privato dell'advisory (italia/bootstrap-italia-ghsa-w459-g4mr-c3mr#1), spostata qui sul repo pubblico su richiesta di @astagi.

### Compatibilità

- **Nessun impatto** per chi passa HTML standard in `text`/`label`/`icon` e schemi URL standard in `link`.
- **Breaking** per chi passa schemi URL esotici (`whatsapp://`, `intent://`, `myapp://`): verrebbero resi come `href="#"`. Questi casi si risolvono per istanza con `{ allowList: allowlistCustom }` oppure `{ sanitize: false }`.
- **Breaking** per chi si aspetta che i caratteri meta digitati nell'input si comportino come pattern: la ricerca ora è letterale. Il comportamento precedente comunque sollevava un errore sulla maggior parte dei meta-caratteri, quindi è improbabile che sia in uso.

### Verifiche effettuate

Test end-to-end in Chrome headless su un bundle IIFE del modulo modificato:

- Item con markup e handler inline nel campo `text` → nessuna esecuzione di JS, tag reso senza attributi di evento, evidenziazione `<mark>` preservata.
- Item con schema `javascript:` nel campo `link` → nessuna esecuzione al click, ancora resa con `href="#"`.
- Digitazione di `(`, `(bar)`, `[` → nessun `SyntaxError`, nessun errore non gestito, la ricerca prosegue.
- Item legittimo (`text`, `link` relativo, `label`, icona sprite SVG) → evidenziazione, `<em>` della label, icona e `href` tutti preservati.
- `{ sanitize: false }` → il markup considerato affidabile dall'integratore passa invariato.
- `allowList` custom con `path` → `<path>` sopravvive al sanitizer.
- `sanitizeFn` custom → la funzione dell'integratore viene eseguita al posto di quella interna.
- `npm run lint-js` pulito.
- `npm run build` produce tutti e quattro i bundle; la modifica è presente in `dist/plugins/input-search-autocomplete.js` e nel bundle UMD.

## Checklist

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<sub>Il markup e il comportamento resi all'utente non cambiano nei casi d'uso documentati, quindi non sono stati rieseguiti i test di accessibilità dedicati; le nuove opzioni sono di configurazione e non hanno riscontro in documentazione — ditemi se preferite che aggiunga una nota in `docs/`.</sub>
