### PR TITLE
fix(transfer): initialize on keyboard interaction, not only on label events

### DIFF
--- a/src/js/plugins/transfer.js
+++ b/src/js/plugins/transfer.js
@@ -29,6 +29,10 @@ const SELECTOR_TRANS_GROUP = '.transfer-group'
 const SELECTOR_SOURCE = `${SELECTOR_TRANS_WRAPPER}.source`
 const SELECTOR_TARGET = `${SELECTOR_TRANS_WRAPPER}.target`
 const SELECTOR_FORM_CHECK = '.form-check'
+// Selettore per l'istanziazione pigra (vedi in fondo al file): deve coprire
+// sia la label sia l'input, perché nel markup del componente l'input è
+// FRATELLO della label e non vi passa mai attraverso.
+const SELECTOR_DATA_API_INIT = `${SELECTOR_BLOCK} ${SELECTOR_FORM_CHECK} label, ${SELECTOR_BLOCK} ${SELECTOR_FORM_CHECK} input`
 
 class Transfer extends BaseComponent {
   constructor(element) {
@@ -251,10 +255,16 @@ class Transfer extends BaseComponent {
  */
 
 if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-  EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_BLOCK + ' .form-check label', function () {
+  // Il componente viene istanziato alla prima interazione. Con il mouse si
+  // clicca la label, l'evento la attraversa e il browser inoltra poi il click
+  // all'input: l'istanza esiste già quando l'input viene attivato. Da tastiera
+  // invece il focus è sull'input, e lo Spazio genera keyup e click direttamente
+  // su di esso senza toccare la label: delegando sulla sola label il componente
+  // non veniva mai istanziato e nessuna interazione da tastiera aveva effetto.
+  EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_API_INIT, function () {
     Transfer.getOrCreateInstance(this.closest(SELECTOR_BLOCK))
   })
-  EventHandler.on(document, EVENT_KEYUP_DATA_API, SELECTOR_BLOCK + ' .form-check label', function () {
+  EventHandler.on(document, EVENT_KEYUP_DATA_API, SELECTOR_DATA_API_INIT, function () {
     Transfer.getOrCreateInstance(this.closest(SELECTOR_BLOCK))
   })
 }


### PR DESCRIPTION
## Descrizione

Fixes #1187

Il componente `Transfer` non risponde alle interazioni da tastiera finché non lo si è usato
almeno una volta con il mouse, come descritto nella issue. La modifica è di due righe nella
delega data-api.

#### Come riprodurre

Sulla pagina di documentazione del componente, **senza toccare il mouse**: raggiungere con Tab
la checkbox di testata "6 ITEMS" e premere Spazio. La checkbox si spunta, ma i sei item della
lista restano deselezionati e il pulsante "Sposta avanti" resta disattivato. Lo stesso vale
attivando da tastiera un singolo item. Dopo un solo click di mouse, la tastiera funziona.

#### Causa

Il componente viene istanziato in modo pigro alla prima interazione, e la delega era agganciata
al solo selettore `[data-bs-transfer] .form-check label`. Nel markup del componente, però,
l'`<input>` è **fratello** della `<label>`, non contenuto in essa:

```html
<div class="form-check">
  <input type="checkbox" id="checkbox1" />
  <label for="checkbox1">...</label>
</div>
```

Con il mouse si clicca la label, l'evento la attraversa, l'istanza viene creata, e solo dopo il
browser inoltra il click all'input, che trova i gestori già agganciati. Da tastiera il focus è
sull'input e lo Spazio genera `keyup` e `click` direttamente su di esso: quegli eventi non
passano mai dalla label, il selettore non corrisponde e il componente non viene mai istanziato.
È il motivo per cui nella issue si legge "senza aver prima usato il mouse".

#### Modifica

La delega ora corrisponde anche all'input. Il selettore è stato estratto in una costante
accanto agli altri `SELECTOR_*` del modulo. Nessuna modifica all'API pubblica, ai tipi, agli
stili o alla documentazione.

#### Comportamento verificato

Su **Chrome 150 headless**, pilotato via Chrome DevTools Protocol: il focus viene portato
sull'input e lo Spazio è un evento di tastiera vero, quindi il toggle della checkbox, l'evento
`click` di attivazione e il loro ordine li genera il browser, non il test.

| Scenario | Atteso | Prima | Dopo |
|---|---|---|---|
| Tastiera, checkbox di testata | 6/6 item selezionati, pulsante attivo | KO | OK |
| Tastiera, singolo item | 1/6 selezionato, pulsante attivo | KO | OK |
| Mouse, checkbox di testata | 6/6 item selezionati, pulsante attivo | OK | OK |
| Mouse, singolo item | 1/6 selezionato, pulsante attivo | OK | OK |

Su Chrome la sequenza reale è `keydown -> keyup -> click -> change`. Poiché non tutti i motori
concordano su questo ordine, gli stessi quattro scenari sono stati ripetuti anche con `click`
prima di `keyup`, su un DOM simulato: il risultato non cambia. La correzione non dipende
dall'ordine, quindi non dovrebbe dipendere dal motore.

#### Una variante scartata

Una prima versione, oltre ad aggiungere l'input alla delega, allineava esplicitamente lo stato
del wrapper subito dopo l'istanziazione. Sistemava la tastiera ma **rompeva il percorso con il
mouse** sulla checkbox di testata, perché la logica finiva per essere eseguita due volte. La
forma minima qui proposta non ha quel problema: quando l'istanza nasce sul `keyup`, i gestori
risultano agganciati prima che il `click` venga distribuito, quindi non serve alcuna
sincronizzazione aggiuntiva.

#### Ambito

Modifica isolata a `src/js/plugins/transfer.js`. `design-react-kit` non è interessato: lì il
componente lega `onChange` direttamente sull'input, quindi tastiera e mouse passano dalla stessa
strada.

#### Nota sulla verifica

La verifica su browser reale copre **Chrome 150**. Non ho potuto provare Firefox e Safari, né
fare un passaggio con uno screen reader, quindi ho lasciato non spuntata la casella sui browser
supportati: preferisco dichiararlo. Resto a disposizione per completare la verifica o per
adeguare la modifica se dovesse emergere altro.

`npm run lint-js`, `prettier --check` e `commitlint` passano. La documentazione non richiede
modifiche: API, markup ed esempi restano invariati.

## Checklist

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata. (non necessaria: nessuna modifica ad API, markup, stili o esempi)
