### PR TITLE
Fix: show mobile icon on upload avatar variant

### DIFF
--- a/docs/form/upload.md
+++ b/docs/form/upload.md
@@ -216,7 +216,7 @@ Ci si aspetta venga caricato un solo file (immagine) il form non ha quindi l'att
           </form>
         </div>
         <div class="avatar-upload-icon">
-          <svg class="icon icon-sm" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-camera"></use></svg>
+          <svg class="icon icon-xs" aria-hidden="true"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-camera"></use></svg>
         </div>
       </div>
     </div>
@@ -463,3 +463,9 @@ const uploadDragDrop = new UploadDragDrop(uploadElement);
     </tr>
   </tbody>
 </table>
+
+## Breaking change
+
+{% capture callout %}
+- Nella variante Avatar - Dimensione Piccola, l'icona presente su mobile ha la classe `.icon-xs` al posto di `.icon-sm`.  
+{% endcapture %}{% include callout-breaking.html content=callout version="3.0.0" type="danger" %}

--- a/src/scss/forms/_form-input-upload.scss
+++ b/src/scss/forms/_form-input-upload.scss
@@ -273,18 +273,18 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 26px;
-    height: 26px;
+    width: 32px;
+    height: 32px;
     border: 2px solid var(--#{$prefix}color-border-inverse);
     border-radius: 50%;
     background: $neutral-1-a1;
     pointer-events: none;
     z-index: 1;
 
-    & > svg {
-      width: 16px;
-      height: 16px;
-    }
+    // & > svg {
+    //   width: 16px;
+    //   height: 16px;
+    // }
   }
 
   &.size-sm {
@@ -294,15 +294,15 @@
     }
 
     .avatar-upload-icon {
-      right: 4px;
-      bottom: 6px;
-      width: 18px;
-      height: 18px;
+      right: 6px;
+      bottom: 8px;
+      width: 24px;
+      height: 24px;
 
-      & > svg {
-        width: 12px;
-        height: 12px;
-      }
+      // & > svg {
+      //   width: 12px;
+      //   height: 12px;
+      // }
     }
   }
 }

--- a/src/scss/forms/_form-input-upload.scss
+++ b/src/scss/forms/_form-input-upload.scss
@@ -263,6 +263,9 @@
 }
 
 .avatar-upload-wrapper {
+    position: relative;
+    display: inline-block;
+
   .avatar-upload-icon {
     position: absolute;
     right: 4px;
@@ -276,6 +279,7 @@
     border-radius: 50%;
     background: $neutral-1-a1;
     pointer-events: none;
+    z-index: 1;
 
     & > svg {
       width: 16px;


### PR DESCRIPTION
## Descrizione

Ref: https://github.com/italia/dev-kit-italia/issues/500

La variante Avatar del componente Upload (Form) non mostra l'icona che dovrebbe. Vedi resa corretta in Dev Kit Italia. 

### Altro

La soluzione andrà validata poi nel prossimo aggiornamento dela dipendenza BSI in Dev Kit Italia e, a latere, sarà da riportare anche in BSI 3 `main` essendo presente anche lì il bug. 

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
