### PR TITLE
fix: collega custom property scollegate in _tab.scss

### DIFF
--- a/src/scss/components/_tab.scss
+++ b/src/scss/components/_tab.scss
@@ -27,7 +27,7 @@
   --#{$prefix}tab-shadow: 0 12px 25px -20px rgba(0, 0, 0, 0.5); // Controls the tab shadow, using elevation tokens.
   --#{$prefix}tab-background-light: var(--#{$prefix}color-background-primary-lighter); // Controls the tab background light, using color tokens.
   --#{$prefix}tab-border-color: transparent; // Controls the tab border color, using border tokens.
-  --#{$prefix}tab-border-width-cards: 2px; // Controls the tab border width cards, using border tokens.
+  --#{$prefix}tab-border-width-cards: 1px; // Controls the tab border width cards, using border tokens.
   --#{$prefix}tab-border-color-cards: var(--#{$prefix}color-border-subtle); // Controls the tab border color cards, using color tokens.
   --#{$prefix}tab-add-btn-border: var(--#{$prefix}color-border-primary); // Controls the tab add btn border, using color tokens.
   --#{$prefix}tab-add-btn-color: var(--#{$prefix}color-background-primary); // Controls the tab add btn color, using color tokens.

--- a/src/scss/components/_tab.scss
+++ b/src/scss/components/_tab.scss
@@ -34,7 +34,7 @@
   --#{$prefix}tab-close-btn-color: var(--#{$prefix}color-text-secondary); // Controls the tab close btn color, using color tokens.
   --#{$prefix}tab-close-btn-color-hover: color-mix(
     in srgb,
-    var(--#{$prefix}primary) 90%,
+    var(--#{$prefix}tab-close-btn-color) 90%,
     black 10%
   ); // Controls the tab close btn color hover, using color tokens.
   --#{$prefix}tab-close-btn-color-disabled: var(--#{$prefix}color-text-disabled); // Controls the tab close btn color disabled, using color tokens.

--- a/src/scss/components/_tab.scss
+++ b/src/scss/components/_tab.scss
@@ -328,9 +328,9 @@
         }
       }
       &:hover {
-        color: shade-color($primary, 10%);
+        color: var(--#{$prefix}tab-close-btn-color-hover);
         .icon {
-          fill: shade-color($primary, 10%);
+          fill: var(--#{$prefix}tab-close-btn-color-hover);
         }
       }
       .it-ico {

--- a/src/scss/components/_tab.scss
+++ b/src/scss/components/_tab.scss
@@ -121,7 +121,7 @@
       --#{$prefix}tab-font-size: var(--#{$prefix}label-font-size-l);
     }
     &:hover {
-      --#{$prefix}tab-text-color: var(--#{$prefix}color-text-secondary-hover);
+      --#{$prefix}tab-text-color: var(--#{$prefix}color-link-secondary-hover);
     }
     &.disabled {
       --#{$prefix}tab-text-color: var(--#{$prefix}color-link-disabled);

--- a/src/scss/components/_tab.scss
+++ b/src/scss/components/_tab.scss
@@ -191,7 +191,7 @@
     &.nav-tabs-vertical-background {
       .nav-link.active,
       .nav-item.show .nav-link {
-        --#{$prefix}tab-background-color: var(--#{$prefix}color-background-primary-lighter);
+        --#{$prefix}tab-background-color: var(--#{$prefix}tab-background-light);
       }
     }
   }
@@ -237,13 +237,13 @@
     &::after {
       content: '';
       flex-grow: 1;
-      border-bottom: 1px solid var(--#{$prefix}color-border-subtle);
+      border-bottom: 1px solid var(--#{$prefix}tab-border-color-cards);
     }
 
     // Tab link styles
     .nav-link {
-      --#{$prefix}tab-border-width: 1px;
-      border-bottom: var(--#{$prefix}tab-border-width) solid var(--#{$prefix}color-border-subtle);
+      --#{$prefix}tab-border-width: var(--#{$prefix}tab-border-width-cards);
+      border-bottom: var(--#{$prefix}tab-border-width) solid var(--#{$prefix}tab-border-color-cards);
       position: relative;
 
       &[data-focus-mouse='true']:not(.active) {
@@ -252,7 +252,7 @@
 
       &.active,
       &[data-focus-mouse='true']:not(:focus) {
-        --#{$prefix}tab-border-color: var(--#{$prefix}color-border-subtle);
+        --#{$prefix}tab-border-color: var(--#{$prefix}tab-border-color-cards);
         border-color: var(--#{$prefix}tab-border-color);
         border-top-width: var(--#{$prefix}tab-border-width);
         border-right-width: var(--#{$prefix}tab-border-width);
@@ -281,7 +281,7 @@
       width: 1.5rem;
       height: 1.5rem;
       margin: -0.2em 1em 0;
-      border: 1px solid var(--#{$prefix}color-border-primary);
+      border: 1px solid var(--#{$prefix}tab-add-btn-border);
       border-radius: 50%;
 
       // Plus sign
@@ -292,7 +292,7 @@
         content: '';
         width: 2px;
         height: 0.778rem;
-        background-color: var(--#{$prefix}color-background-primary);
+        background-color: var(--#{$prefix}tab-add-btn-color);
       }
       &:before {
         position: absolute;
@@ -301,7 +301,7 @@
         content: '';
         width: 0.778rem;
         height: 2px;
-        background-color: var(--#{$prefix}color-background-primary);
+        background-color: var(--#{$prefix}tab-add-btn-color);
       }
     }
 
@@ -314,14 +314,14 @@
       position: absolute;
       top: calc(50% - 1rem);
       right: 0.889rem;
-      color: var(--#{$prefix}color-text-secondary);
+      color: var(--#{$prefix}tab-close-btn-color);
       transition: color 0.2s;
       cursor: pointer;
       .icon {
         fill: var(--#{$prefix}icon-secondary);
       }
       &.disabled {
-        color: var(--#{$prefix}color-text-disabled);
+        color: var(--#{$prefix}tab-close-btn-color-disabled);
         cursor: pointer;
         .icon {
           fill: var(--#{$prefix}icon-disabled);
@@ -403,7 +403,7 @@
 
 @include media-breakpoint-down(md) {
   .nav-tabs {
-    box-shadow: 0 12px 25px -20px rgba(0, 0, 0, 0.5);
+    box-shadow: var(--#{$prefix}tab-shadow);
     &.nav-tabs-vertical,
     &.nav-tabs-cards {
       box-shadow: none;


### PR DESCRIPTION
## Cosa

Refs #1888

Fix di tutte e 9 le custom property di `_tab.scss` risultate "dichiarate ma mai lette", più due bug distinti trovati durante la verifica cross-repo. 

- 6 refusi di collegamento puramente meccanici, nessun cambio visivo
- `tab-border-width-cards`: cambio di default (2px → 1px, allineato al valore realmente in uso)
- `tab-close-btn-color-hover`: sostituito il calcolo Sass compile-time con il token CSS runtime già dichiarato (importante per il theming con prefix personalizzato)
- `tab-background-light`: mai collegata dall'introduzione (`dda305c81`), confermato via `git log -S` che non è separazione intenzionale
- Due orfane trovate in verifica, entrambe nate in `dda305c81`: `.nav-link:hover` leggeva `color-text-secondary-hover` (mai esistita) → ricollegata a `color-link-secondary-hover`, stesso token usato in `_breadcrumb.scss`/`_buttons.scss`. `tab-close-btn-color-hover` calcolava un `color-mix()` con `--#{$prefix}primary` (mai esistita a runtime) → corretto mixando con la property sorella `tab-close-btn-color`.

## Verifica

- Script di audit, zero property dead su Tabs.
- Compilazione SCSS completa ok.
- Verifica visiva in staging: nessuna differenza rispetto a prima, tranne la riapparizione dell'hover sul pulsante di chiusura (da nero a grigio scurito) e sul testo del tab (da nero a `color-link-secondary-hover`).

## Verifica impatto Dev Kit Italia

✅ **Verificato, nessun impatto dai 9 fix**: `it-tab`/`it-tabs` sono una reimplementazione completa via Web Components (pattern flat-tree), non un consumer di stile di `_tab.scss` — dismiss button reimplementato indipendentemente via `currentColor`, gli altri quattro token (`tab-shadow`/`tab-background-light`/`tab-border-width-cards`/`tab-border-color-cards`) sono ridichiarati come letterali "own" su `:host`, non ereditati.

⚠️ **Stesso refuso indipendente trovato**: `it-tab.scss`, `:host(:hover)`, legge `var(--it-tab_hover-text-color, var(--#{$prefix}color-text-secondary-hover))` — stesso nome orfano appena corretto in BSI, ma scritto indipendentemente in Dev Kit (il file non importa `_tab.scss`, il fix qui non si propaga). Fix suggerito identico: `var(--#{$prefix}color-link-secondary-hover)`.

⚠️ **Rischio strutturale per il futuro, non bloccante**: i quattro token ridichiarati come letterali su `:host` in Dev Kit non erediteranno mai un futuro cambio di default lato BSI — serve uno specchio manuale, a differenza di dropdown (#1894, import diretto, propagazione automatica). Nessuna azione richiesta ora.

FYI @deodorhunter

## Checklist

- [ ] Le modifiche sono conformi alle linee guida di design.
- [ ] Il codice è coerente con le indicazioni di progetto.
- [ ] Le modifiche sono state verificate sui browser supportati e per diverse risoluzioni.
- [ ] Sono stati effettuati test di accessibilità.
- [ ] La documentazione è stata aggiornata.