### PR TITLE
fix: pulizia custom property in _dropdown.scss

### DIFF
--- a/src/scss/components/_dropdown.scss
+++ b/src/scss/components/_dropdown.scss
@@ -38,9 +38,7 @@
   --#{$prefix}dropdown-inner-border-radius: var(--#{$prefix}radius-smooth); // Controls the inner border radius for first and last items, using radius tokens.
   --#{$prefix}dropdown-item-padding-x: var(--#{$prefix}spacing-s); // Controls the dropdown item padding left and right, using spacing tokens.
   --#{$prefix}dropdown-item-padding-y: var(--#{$prefix}spacing-xs); // Controls the dropdown item padding top and bottom, using spacing tokens.
-  --#{$prefix}dropdown-link-active-color: var(--#{$prefix}color-text-primary-active); // Controls the active link color, using color tokens.
   --#{$prefix}dropdown-link-color: var(--#{$prefix}color-text-primary); // Controls the link color in dropdown items, using color tokens.
-  --#{$prefix}dropdown-link-hover-color: var(--#{$prefix}color-text-primary-hover); // Controls the link hover color in dropdown items, using color tokens.
   --#{$prefix}dropdown-min-width: 10rem; // Controls the minimum width of the dropdown menu.
   --#{$prefix}dropdown-notch-base-size: 1.125rem; // Controls the size of the notch element.
   --#{$prefix}dropdown-notch-position-x: 20px; // Controls the x position of the notch element.
@@ -162,7 +160,6 @@
     --#{$prefix}dropdown-background: var(--#{$prefix}color-background-primary-muted);
     --#{$prefix}dropdown-link-color: var(--#{$prefix}color-text-inverse);
     --#{$prefix}dropdown-divider-bg: var(--#{$prefix}color-border-subtle);
-    --#{$prefix}dropdown-link-active-color: var(--#{$prefix}color-text-inverse);
     --#{$prefix}dropdown-header-color: var(--#{$prefix}color-text-inverse);
 
     // Notch element
@@ -430,8 +427,6 @@
 // Dropdown button
 .btn-dropdown {
   --#{$prefix}dropdown-button-color: var(--#{$prefix}color-text-primary);
-  --#{$prefix}dropdown-button-padding: 10px;
-  --#{$prefix}dropdown-button-background: #fff;
   border-radius: 0;
   box-shadow: none;
   color: var(--#{$prefix}dropdown-button-color);

--- a/src/scss/components/_dropdown.scss
+++ b/src/scss/components/_dropdown.scss
@@ -158,7 +158,7 @@
 
   // Dropdown on dark background
   &.dark {
-    --#{$prefix}dropdown-text-color: var(--#{$prefix}color-text-inverse);
+    --#{$prefix}dropdown-color: var(--#{$prefix}color-text-inverse);
     --#{$prefix}dropdown-background: var(--#{$prefix}color-background-primary-muted);
     --#{$prefix}dropdown-link-color: var(--#{$prefix}color-text-inverse);
     --#{$prefix}dropdown-divider-bg: var(--#{$prefix}color-border-subtle);


### PR DESCRIPTION
## Cosa

Refs #1888

Fix di property scollegate/orfane su `_dropdown.scss`. 

- `dropdown-text-color` (variante `.dark`): non un refuso di naming, un bug — la property letta realmente è `dropdown-color`. Corretto, il testo del dropdown scuro ora prende davvero `color-text-inverse`.
- `dropdown-link-active-color`/`dropdown-link-hover-color`: **rimosse**. Stato attivo/hover già gestito da `_link-list.scss` sul vero markup usato (`.list-item`), ridondanti fin dall'introduzione.
- `dropdown-button-background`/`dropdown-button-padding`: **rimosse**. `.btn-dropdown` è sempre accoppiata a `.btn`, che fornisce già background/padding via i propri token — mai avuto effetto.

Non toccata `dropdown-position`: risulta "morta" per lo script solo perché letta da `dropdown.js` (Popper), non da SCSS — falso positivo strutturale, lo script guarda solo file `.scss`. Da capire se estenderlo.

## Nota per la review

⚠️ **Bug trovato, fuori scope qui**: in `dropdown.js` il prefix è hardcoded (`--bsi-dropdown-position` letterale) invece di derivare da `$prefix` — con un prefix personalizzato il posizionamento del dropdown smette di funzionare silenziosamente (già segnalato da un commento nel file). Issue a parte da aprire, probabile debito JS/build imparentato con la migrazione dei file `*theme.scss`.

## Verifica impatto Dev Kit Italia

✅ **Verificato, propagazione automatica**: `_dropdown.scss` importata direttamente via `@use` in `dropdown/styles/globals.scss`.

- `dropdown-text-color`→`dropdown-color`: beneficia anche `it-dropdown` (`.dark` lì aggiunge solo `dropdown-header-color`/`color-border-subtle` sopra quanto eredita da questa partial).
- `dropdown-button-background`/`-padding`: nessun impatto — il trigger di `it-dropdown` è `<it-button>`, non usa `.btn-dropdown`.
- `dropdown-link-active-color`/`-hover-color`: nessun impatto — `dropdown-item.scss` usa `color-text-primary-active`/`color-link-hover`, mai i due token rimossi qui.
- `dropdown-position`: nessun impatto — il positioning di `it-dropdown` è delegato a `<it-popover>`, componente proprio, non a `dropdown.js` di BSI.

FYI @deodorhunter

## Checklist

- [ ] Le modifiche sono conformi alle linee guida di design.
- [ ] Il codice è coerente con le indicazioni di progetto.
- [ ] Le modifiche sono state verificate sui browser supportati e per diverse risoluzioni.
- [ ] Sono stati effettuati test di accessibilità.
- [ ] La documentazione è stata aggiornata.
