### PR TITLE
fix: collega custom property scollegate in _accept-overlay.scss, _alert.scss, _badge.scss

### DIFF
--- a/docs/componenti/video-player.md
+++ b/docs/componenti/video-player.md
@@ -424,7 +424,7 @@ In questo la Pubblica Amministrazione che fa uso di servizi di terze parti come 
       <div class="acceptoverlay-icon">
         <svg class="icon icon-xl"><use href="{{ site.baseurl }}/dist/svg/sprites.svg#it-video"></use></svg>
       </div>
-        <p>Accetta i cookie di YouTube per vedere il video. Puoi gestire le preferenze nella <a href="#" class="text-white">cookie policy</a>.
+        <p>Accetta i cookie di YouTube per vedere il video. Puoi gestire le preferenze nella <a href="#">cookie policy</a>.
         </p>
       <div class="acceptoverlay-buttons bg-dark">
         <button type="button" class="btn btn-primary" data-bs-accept-from="youtube.com"

--- a/src/scss/components/_accept-overlay.scss
+++ b/src/scss/components/_accept-overlay.scss
@@ -42,6 +42,11 @@
   justify-content: center;
   padding: var(--#{$prefix}acceptoverlay-spacing-inset);
   background-color: var(--#{$prefix}acceptoverlay-background-color);
+
+  a {
+    color: var(--#{$prefix}color-link-inverse);
+  }
+
   // Change spacing on medium devices
   @include media-breakpoint-up(md) {
     --#{$prefix}acceptoverlay-spacing-inset: var(--#{$prefix}spacing-m);

--- a/src/scss/components/_accept-overlay.scss
+++ b/src/scss/components/_accept-overlay.scss
@@ -13,7 +13,9 @@
 // Properties
 //
 .acceptoverlay {
-  --#{$prefix}acceptoverlay-color-background: var(--#{$prefix}color-background-inverse); // Controls the acceptoverlay color background, using color tokens
+  --#{$prefix}acceptoverlay-background-color: var(
+    --#{$prefix}overlay-background-primary-muted
+  ); // Controls the acceptoverlay color background, using color tokens
   --#{$prefix}acceptoverlay-color-text: var(--#{$prefix}color-text-inverse); // Controls the acceptoverlay color text, using color tokens
   --#{$prefix}acceptoverlay-label-color: var(--#{$prefix}color-text-inverse); // Controls the acceptoverlay label color, using color tokens
   --#{$prefix}acceptoverlay-label-border-color: var(--#{$prefix}color-border-inverse); // Controls the acceptoverlay label border color, using color tokens

--- a/src/scss/components/_accept-overlay.scss
+++ b/src/scss/components/_accept-overlay.scss
@@ -26,6 +26,7 @@
   --#{$prefix}acceptoverlay-icon-fill: var(--#{$prefix}icon-inverse); // Controls the acceptoverlay icon fill, using color tokens
   --#{$prefix}acceptoverlay-buttons-spacing: var(--#{$prefix}spacing-s); // Controls the acceptoverlay buttons spacing, using spacing tokens
 }
+
 // Styles
 //
 /* stylelint-disable-next-line no-duplicate-selectors */
@@ -51,6 +52,7 @@
   @include media-breakpoint-up(md) {
     --#{$prefix}acceptoverlay-spacing-inset: var(--#{$prefix}spacing-m);
   }
+
   // Change alignment on large devices
   @include media-breakpoint-up(lg) {
     align-items: center;
@@ -58,6 +60,7 @@
 
   label {
     color: var(--#{$prefix}acceptoverlay-label-color);
+
     &::after {
       border-color: var(--#{$prefix}acceptoverlay-label-border-color) !important;
     }
@@ -69,6 +72,7 @@
 
   &.acceptoverlay-primary {
     --#{$prefix}acceptoverlay-background-color: var(--#{$prefix}color-background-primary);
+
     &.show {
       --#{$prefix}acceptoverlay-background-color: color-mix(
         in srgb,
@@ -105,6 +109,7 @@
   .acceptoverlay-icon {
     margin-bottom: var(--#{$prefix}acceptoverlay-icon-spacing);
     text-align: center;
+
     @include media-breakpoint-up(md) {
       --#{$prefix}acceptoverlay-icon-spacing: var(--#{$prefix}spacing-xxl);
     }
@@ -125,6 +130,7 @@
 
     button {
       width: 100%;
+
       &:last-child {
         --#{$prefix}acceptoverlay-buttons-spacing: var(--#{$prefix}spacing-xxs);
       }
@@ -137,17 +143,21 @@
     }
   }
 }
+
 //Tablet vertical
 @include media-breakpoint-up(md) {
   .acceptoverlay-buttons {
     flex-wrap: nowrap;
+
     button {
       width: 50%;
       margin-top: 0 !important;
+
       &:last-child {
         margin-left: var(--#{$prefix}spacing-m);
       }
     }
+
     &.single-button {
       button {
         width: auto;
@@ -160,6 +170,7 @@
 
 .acceptoverlayable {
   position: relative;
+
   &.show {
     min-height: 450px;
   }

--- a/src/scss/components/_accept-overlay.scss
+++ b/src/scss/components/_accept-overlay.scss
@@ -99,7 +99,7 @@
     margin-bottom: var(--#{$prefix}acceptoverlay-icon-spacing);
     text-align: center;
     @include media-breakpoint-up(md) {
-      --#{$prefix}acceptoverlay-icon-margin-bottom: var(--#{$prefix}spacing-xxl);
+      --#{$prefix}acceptoverlay-icon-spacing: var(--#{$prefix}spacing-xxl);
     }
 
     .icon {

--- a/src/scss/components/_accept-overlay.scss
+++ b/src/scss/components/_accept-overlay.scss
@@ -19,9 +19,8 @@
   --#{$prefix}acceptoverlay-color-text: var(--#{$prefix}color-text-inverse); // Controls the acceptoverlay color text, using color tokens
   --#{$prefix}acceptoverlay-label-color: var(--#{$prefix}color-text-inverse); // Controls the acceptoverlay label color, using color tokens
   --#{$prefix}acceptoverlay-label-border-color: var(--#{$prefix}color-border-inverse); // Controls the acceptoverlay label border color, using color tokens
-  --#{$prefix}acceptoverlay-opacity: 0.9; // Controls the acceptoverlay opacity
   --#{$prefix}acceptoverlay-spacing-inset: var(--#{$prefix}spacing-s); // Controls the acceptoverlay spacing inset, using spacing tokens
-  --#{$prefix}acceptoverlay-primary-opacity: 0.95; // Controls the acceptoverlay primary opacity
+  --#{$prefix}acceptoverlay-primary-opacity: 95%; // Controls the acceptoverlay primary opacity
   --#{$prefix}acceptoverlay-inner-width: 600px; // Controls the acceptoverlay inner width
   --#{$prefix}acceptoverlay-icon-spacing: var(--#{$prefix}spacing-s); // Controls the acceptoverlay icon spacing, using spacing tokens
   --#{$prefix}acceptoverlay-icon-fill: var(--#{$prefix}icon-inverse); // Controls the acceptoverlay icon fill, using color tokens
@@ -42,7 +41,6 @@
   align-items: flex-start;
   justify-content: center;
   padding: var(--#{$prefix}acceptoverlay-spacing-inset);
-  opacity: var(--#{$prefix}acceptoverlay-opacity);
   background-color: var(--#{$prefix}acceptoverlay-background-color);
   // Change spacing on medium devices
   @include media-breakpoint-up(md) {
@@ -67,7 +65,11 @@
   &.acceptoverlay-primary {
     --#{$prefix}acceptoverlay-background-color: var(--#{$prefix}color-background-primary);
     &.show {
-      opacity: var(--#{$prefix}acceptoverlay-primary-opacity);
+      --#{$prefix}acceptoverlay-background-color: color-mix(
+        in srgb,
+        var(--#{$prefix}color-background-primary) var(--#{$prefix}acceptoverlay-primary-opacity),
+        transparent
+      );
     }
   }
 

--- a/src/scss/components/_accept-overlay.scss
+++ b/src/scss/components/_accept-overlay.scss
@@ -24,7 +24,7 @@
   --#{$prefix}acceptoverlay-primary-opacity: 0.95; // Controls the acceptoverlay primary opacity
   --#{$prefix}acceptoverlay-inner-width: 600px; // Controls the acceptoverlay inner width
   --#{$prefix}acceptoverlay-icon-spacing: var(--#{$prefix}spacing-s); // Controls the acceptoverlay icon spacing, using spacing tokens
-  --#{$prefix}acceptoverlay-icon-fill: var(--#{$prefix}icon-primary); // Controls the acceptoverlay icon fill, using color tokens
+  --#{$prefix}acceptoverlay-icon-fill: var(--#{$prefix}icon-inverse); // Controls the acceptoverlay icon fill, using color tokens
   --#{$prefix}acceptoverlay-buttons-spacing: var(--#{$prefix}spacing-s); // Controls the acceptoverlay buttons spacing, using spacing tokens
 }
 // Styles

--- a/src/scss/components/_alert.scss
+++ b/src/scss/components/_alert.scss
@@ -23,7 +23,7 @@
   --#{$prefix}alert-icon-spacing: var(--#{$prefix}icon-spacing); // Controls the icon spacing for the alert, using spacing tokens.
   --#{$prefix}alert-spacing-inset: var(--#{$prefix}spacing-s); // Controls the inset spacing for the alert, using spacing tokens.
   --#{$prefix}alert-spacing-inset-extra: var(--#{$prefix}spacing-xxl); // Controls the extra inset spacing for the alert, using spacing tokens.
-  --#{$prefix}alert-spacing-outside: var(--#{$prefix}spacing-m); // Controls the outside spacing for the alert, using spacing tokens.
+  --#{$prefix}alert-spacing-outside: 0; // Controls the outside spacing for the alert, using spacing tokens.
   --#{$prefix}alert-text-color: var(--#{$prefix}color-text-base); // Controls the text color for the alert, using color tokens.
 }
 
@@ -32,14 +32,14 @@
 /* stylelint-disable-next-line no-duplicate-selectors */
 .alert {
   position: relative;
-  margin-bottom: var(--#{$prefix}alert-margin);
+  margin-bottom: var(--#{$prefix}alert-spacing-outside);
   padding: var(--#{$prefix}alert-spacing-inset);
   border: 1px solid var(--#{$prefix}alert-border-color);
   background-color: var(--#{$prefix}alert-background-color);
   color: var(--#{$prefix}alert-text-color);
 
   @include media-breakpoint-up(lg) {
-    --#{$prefix}alert-spacing-inset: var(-#{$prefix}spacing-inset-m);
+    --#{$prefix}alert-spacing-inset: var(--#{$prefix}spacing-s);
     padding-left: var(--#{$prefix}alert-spacing-inset);
   }
 }

--- a/src/scss/components/_badge.scss
+++ b/src/scss/components/_badge.scss
@@ -2,7 +2,6 @@
 @use '../base/variables' as *;
 @use '../base/mixins/border-radius' as *;
 @use '../base/mixins/gradients' as *;
-@use '../base/vendor/rfs' as *;
 @use '../base/maps' as *;
 
 // Component: badge
@@ -19,7 +18,7 @@
 .badge {
   --#{$prefix}badge-border-radius: var(--#{$prefix}radius-smooth); // Controls the border radius for the badge, using radius tokens.
   --#{$prefix}badge-font-size: var(--#{$prefix}label-font-size-s); // Controls the font size for the badge, using font tokens.
-  --#{$prefix}badge-font-size-relative: 0.75em; // Controls the relative font size for the badge.
+  --#{$prefix}badge-font-size-relative: 1em; // Controls the relative font size for the badge.
   --#{$prefix}badge-font-weight: var(--#{$prefix}font-weight-solid); // Controls the font weight for the badge, using font tokens.
   --#{$prefix}badge-padding-x: var(--#{$prefix}spacing-xs); // Controls the horizontal padding for the badge, using spacing tokens.
   --#{$prefix}badge-padding-y: var(--#{$prefix}spacing-3xs); // Controls the vertical padding for the badge, using spacing tokens.
@@ -33,6 +32,7 @@
   display: inline-block;
   padding: var(--#{$prefix}badge-padding-y) var(--#{$prefix}badge-padding-x);
   color: var(--#{$prefix}badge-text-color);
+  font-size: var(--#{$prefix}badge-font-size-relative);
   font-weight: var(--#{$prefix}badge-font-weight);
   line-height: 1;
   text-align: center;
@@ -43,7 +43,6 @@
     background-color var(--#{$prefix}transition-instant) ease-in-out,
     border-color var(--#{$prefix}transition-instant) ease-in-out,
     box-shadow var(--#{$prefix}transition-instant) ease-in-out;
-  @include rfs($badge-font-size, --#{$prefix}badge-font-size);
   @include border-radius(var(--#{$prefix}badge-border-radius));
 
   // Empty badges collapse automatically

--- a/src/scss/components/_badge.scss
+++ b/src/scss/components/_badge.scss
@@ -17,7 +17,6 @@
 
 .badge {
   --#{$prefix}badge-border-radius: var(--#{$prefix}radius-smooth); // Controls the border radius for the badge, using radius tokens.
-  --#{$prefix}badge-font-size: var(--#{$prefix}label-font-size-s); // Controls the font size for the badge, using font tokens.
   --#{$prefix}badge-font-size-relative: 1em; // Controls the relative font size for the badge.
   --#{$prefix}badge-font-weight: var(--#{$prefix}font-weight-solid); // Controls the font weight for the badge, using font tokens.
   --#{$prefix}badge-padding-x: var(--#{$prefix}spacing-xs); // Controls the horizontal padding for the badge, using spacing tokens.


### PR DESCRIPTION
## Cosa

Refs #1888

Fix di property scollegate/orfane su `_accept-overlay.scss`, `_alert.scss`, `_badge.scss`. Due property pubbliche rimosse (`acceptoverlay-opacity`, `badge-font-size`), mai state la reale fonte di verità del rendering. 

- **`_accept-overlay.scss`**: `acceptoverlay-color-background` → rinominata `acceptoverlay-background-color` (convenzione naming). `acceptoverlay-icon-margin-bottom` collegata (spacing extra su tablet/desktop ora scatta). Bug di contrasto trovato: `acceptoverlay-icon-fill` aveva default blu su sfondo blu, icona sostanzialmente invisibile — allineato al componente gemello `_dimmer.scss` (testo/label/icona sempre `*-inverse`, background `overlay-background-primary-muted`, trasparenza via `color-mix()` scoped invece di `opacity` generico). `acceptoverlay-opacity` rimossa, ridondante col nuovo approccio. Link interni ora usano `color-link-inverse` invece della classe `.text-white` hardcoded nel markup doc (rimossa lì, non segnata come breaking perché retro-compatibile).
- **`_alert.scss`**: `alert-spacing-outside` collegata (leggeva un nome mai dichiarato), default `0`. Corretto un trattino mancante nel breakpoint `lg` (CSS non valido, puntava anche a un token mai esistito) — punta ora a `spacing-s`, visivamente neutro.
- **`_badge.scss`**: `badge-font-size-relative` collegata, rimosso il mixin `rfs()` — con input in `em` (`$badge-font-size`, 0.75em) non calcola nulla di fluido, lo passa invariato (verificato in `_rfs.scss`) — default `1em` per corrispondere al comportamento ereditato attuale. `badge-font-size` **rimossa** — non era mai la reale fonte di verità del font-size (stesso tipo di rimozione già fatto in #1894 per `dropdown-button-background`/`-padding`).

## Nota per la review

⚠️ **Bug trovato incidentalmente, non toccato in questa PR**: `accept-overlay.js` → `_showElement()` usa `this._overlayable.add(CLASS_NAME_SHOW)` invece di `this._overlayable.classList.add(...)` — la classe `.show` non viene mai aggiunta nel path `show()`. Issue a parte da aprire, @astagi.

## Verifica impatto Dev Kit Italia

✅ **Nessuna azione richiesta**: `alert` (nessun CSS dedicato), `badge` (solo bundle documentazione, nessuno stile proprio).

⚠️ **`accept-overlay`**: in `videoplayer/styles/globals.scss`, `acceptoverlay-color-text` viene ridichiarata localmente a `#fff` hardcoded invece di ereditare il token — stessa famiglia di fix già trovati su avatar/bottomnav. Da valutare se correggere a valle del merge, FYI @deodorhunter.

## Checklist

- [ ] Le modifiche sono conformi alle linee guida di design.
- [ ] Il codice è coerente con le indicazioni di progetto.
- [ ] Le modifiche sono state verificate sui browser supportati e per diverse risoluzioni.
- [ ] Sono stati effettuati test di accessibilità.
- [ ] La documentazione è stata aggiornata.