### PR TITLE
fix: --navbar-link-border-color var with prefix

### DIFF
--- a/src/scss/components/_navbar.scss
+++ b/src/scss/components/_navbar.scss
@@ -365,7 +365,7 @@
       a.nav-link {
         --#{$prefix}navbar-link-border-color: transparent;
         border-bottom: 0;
-        border-left: var(--#{$prefix}navbar-link-border-size) solid var(--navbar-link-border-color);
+        border-left: var(--#{$prefix}navbar-link-border-size) solid var(--#{$prefix}navbar-link-border-color);
         background: transparent;
         font-weight: var(--#{$prefix}navbar-link-font-weight);
         text-align: left;
@@ -373,13 +373,13 @@
           --#{$prefix}navbar-link-padding-x: var(--#{$prefix}spacing-s); // reduce horizontal padding for desktop
           display: flex;
           align-items: center;
-          border-bottom: var(--#{$prefix}navbar-link-border-size) solid var(--navbar-link-border-color);
+          border-bottom: var(--#{$prefix}navbar-link-border-size) solid var(--#{$prefix}navbar-link-border-color);
           border-left: 0;
           line-height: var(--#{$prefix}navbar-link-line-height);
         }
 
         &.active {
-          --navbar-link-border-color: var(--#{$prefix}navbar-link-active-border-color);
+          --#{$prefix}navbar-link-border-color: var(--#{$prefix}navbar-link-active-border-color);
         }
 
         &.dropdown-toggle.show[data-focus-mouse='true'] {


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

c'era una variabile css (`--navbar-link-border-color`) che non era stata aggiornata all'uso del prefix. Pertanto su devkit italia, si faceva affidamento ad alcuni di questi stili che però non usavano la variabile corretta. 


## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
