### PR TITLE
Fix aria-controls attribute in callout-breaking.html

### DIFF
--- a/_includes/callout-breaking.html
+++ b/_includes/callout-breaking.html
@@ -6,7 +6,7 @@ danger, warning {%- endcomment -%}
   <div class="accordion-item">
     <h4 class="accordion-header" id="#bsbrh{{id_collapse}}">
       <button class="accordion-button text-black collapsed" type="button" style="border-top: none;" data-bs-toggle="collapse" data-bs-target="#bsbrc{{id_collapse}}"
-      aria-controls="#bsbrc{{id_collapse}}">
+      aria-controls="bsbrc{{id_collapse}}">
       Breaking change dalla versione&nbsp;<b>{{include.version}}</b>
       </button>
     </h4>


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

I valori aria devono puntare a valori validi. C'è un "#" di troppo nel nome id di questo button accordion. 

⚠️ **Già sistemato anche su su ramo 3.x qui: https://github.com/italia/bootstrap-italia/pull/1777/changes/2da011e45a110d6e78ff753bf4f949be4b71322a**

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
