### PR TITLE
fix: prefix hardcoded in `var()` invece di `$prefix`

### DIFF
--- a/docs/assets/src/scss/_font-switcher.scss
+++ b/docs/assets/src/scss/_font-switcher.scss
@@ -1,19 +1,15 @@
+@use 'src/scss/base/config' as *;
+@use 'src/scss/base/variables' as *;
+
 .font-switcher {
   .btn {
-    font-size: 0.8rem;
-    border-color: #dee2e6;
+    --#{$prefix}btn-font-size: var(--#{$prefix}label-font-size-s);
   }
 
   .dropdown-item {
     &.active {
-      background-color: var(--bsi-primary);
+      background-color: var(--#{$prefix}color-background-primary);
       color: white;
-
-      &:focus,
-      &:hover {
-        background-color: var(--bsi-primary);
-        color: white;
-      }
     }
   }
 }

--- a/src/scss/base/_maps.scss
+++ b/src/scss/base/_maps.scss
@@ -65,10 +65,10 @@ $gutters: $spacers !default;
 
 // Colors Palette
 $colors-palette: (
-  'primary': var(--bsi-color-background-primary),
-  'secondary': var(--bsi-color-background-secondary),
-  'success': var(--bsi-color-background-success),
-  'warning': var(--bsi-color-background-warning),
-  'danger': var(--bsi-color-background-danger),
-  'inverse': var(--bsi-color-background-inverse),
+  'primary': var(--#{$prefix}color-background-primary),
+  'secondary': var(--#{$prefix}color-background-secondary),
+  'success': var(--#{$prefix}color-background-success),
+  'warning': var(--#{$prefix}color-background-warning),
+  'danger': var(--#{$prefix}color-background-danger),
+  'inverse': var(--#{$prefix}color-background-inverse),
 ) !default;

--- a/src/scss/components/_tables.scss
+++ b/src/scss/components/_tables.scss
@@ -61,9 +61,9 @@ $table-variants: (
   --#{$prefix}table-border-width: var(--#{$prefix}border-width); // Controls the border width for the table cell.
   --#{$prefix}table-striped-bg: var(--#{$prefix}color-background-muted); // Controls the text color for the striped rows, using color tokens.
   --#{$prefix}table-striped-color: var(--#{$prefix}table-color); // Controls the text color for the striped rows, using color tokens.
-  --#{$prefix}table-active-bg: var(--bsi-color-slate-85); // Controls the background color for the active rows, using color tokens.
+  --#{$prefix}table-active-bg: var(--#{$prefix}color-slate-85); // Controls the background color for the active rows, using color tokens.
   --#{$prefix}table-hover-color: var(--#{$prefix}color-text-base); // Controls the text color for the hovered rows, using color tokens.
-  --#{$prefix}table-hover-bg: var(--bsi-color-slate-85); // Controls the background color for the hovered rows, using color tokens.
+  --#{$prefix}table-hover-bg: var(--#{$prefix}color-slate-85); // Controls the background color for the hovered rows, using color tokens.
   --#{$prefix}table-padding: var(--#{$prefix}spacing-xxs); // Controls the padding for the table cells, using spacing tokens.
   --#{$prefix}table-cell-font-size: var(--#{$prefix}body-font-size); // Controls the font size for the table cells, using typography tokens.
   --#{$prefix}table-cell-vertical-align: top; // Controls the vertical alignment of the table cells.

--- a/src/scss/components/_timeline.scss
+++ b/src/scss/components/_timeline.scss
@@ -144,8 +144,8 @@
       background: var(--#{$prefix}timeline-pin-background);
       border-radius: var(--#{$prefix}radius-rounded);
       font-family: var(--#{$prefix}font-mono);
-      font-size: var(--bs-body-font-size);
-      line-height: var(--bs-body-line-height);
+      font-size: var(--#{$prefix}body-font-size);
+      line-height: var(--#{$prefix}body-leading);
 
       span {
         padding: var(--#{$prefix}spacing-3xs) var(--#{$prefix}spacing-s);

--- a/src/scss/utilities/icons.scss
+++ b/src/scss/utilities/icons.scss
@@ -67,7 +67,7 @@ $icon-colors: (
 // It is used in the buttons.
 //
 :root {
-  --#{$prefix}rounded-icon-size: var(--bsi-icon-size-s);
+  --#{$prefix}rounded-icon-size: var(--#{$prefix}icon-size-s);
 }
 
 .rounded-icon {


### PR DESCRIPTION
## Cosa

Corretti riferimenti a custom property con prefisso letterale (`bsi-` o `bs-`) al posto di `#{$prefix}`, in 5 file: `icons.scss`, `_tables.scss`, `_maps.scss`, `_font-switcher.scss`, `_timeline.scss`.

## Perché

Il prefisso hardcoded rompe la personalizzazione per chi cambia `$prefix` di default. Due casi non erano solo sintassi:

- `_font-switcher.scss`: `--bsi-primary` non è mai esistito in `root.scss` (introdotto per errore in un fix precedente) — lo  sfondo dell'item attivo era di fatto assente, non solo a rischio. Corretto anche `$prefix` non in scope (mancava l'`@use`).
- `_timeline.scss`: leggeva token Bootstrap nativi (`--bs-body-font-size`/`--bs-body-line-height`) invece dei token BSI equivalenti (`body-font-size`/`body-leading`) — valori numericamente identici, nessun impatto.

Gli altri tre (`icons.scss`, `_tables.scss`, `_maps.scss`) sono fix di sola sintassi, default invariato, impatto zero.

## ✅ Verifica impatto Dev Kit Italia

- **icon**: legge `--#{$prefix}icon-size-s` (token base), non `rounded-icon-size` toccata dal fix — nessuna sovrapposizione.
- **tables**: nessun file scss dedicato, consuma il CSS BSI in blocco.
- **maps / $colors-palette**: `_alert.scss` in Dev Kit importa `$colors-palette` via `@use` diretto dal sorgente BSI. Il fix si
  propaga al prossimo build, nessuna azione separata.
- **timeline**: Dev Kit legge già `--#{$prefix}body-font-size`/ `--#{$prefix}body-leading` correttamente in `timeline-point.scss` e `timeline-element.scss`. Il fix allinea la sorgente BSI a quanto Dev Kit già faceva, nessun rischio.
- `_font-switcher.scss` è sotto `docs/assets/`, fuori dal perimetro CSS che Dev Kit consuma, non applicabile.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://designers.italia.it/linee-guida).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
